### PR TITLE
Update SDK to latest version and fix 'Tag' field assignment

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   projects/node-sdk:
     dependencies:
       '@fingerprintjs/fingerprintjs-pro-server-api':
-        specifier: ^6.3.0
-        version: 6.3.0
+        specifier: ^6.4.0
+        version: 6.4.0
       express:
         specifier: ^5.0.1
         version: 5.0.1
@@ -92,6 +92,10 @@ packages:
 
   '@fingerprintjs/fingerprintjs-pro-server-api@6.3.0':
     resolution: {integrity: sha512-Kig3A+sEBoTvOXqgj+MvND2prF6WId/bO/vCz4ZMUhW8s4FRRv5SUohcH+k5npdwTJy3t6qSZP7DUPYNM/PEsg==}
+    engines: {node: '>=18.17.0'}
+
+  '@fingerprintjs/fingerprintjs-pro-server-api@6.4.0':
+    resolution: {integrity: sha512-WDn271RNJKLTabnyjNVBb595XtoRGWits/p8nqrE0VfEy0YX5n74ThEaw8YWaPObkxPQNoNjPKrHCTjgKH9CZw==}
     engines: {node: '>=18.17.0'}
 
   '@fingerprintjs/fingerprintjs-pro@3.11.6':
@@ -1103,6 +1107,8 @@ snapshots:
       - typescript
 
   '@fingerprintjs/fingerprintjs-pro-server-api@6.3.0': {}
+
+  '@fingerprintjs/fingerprintjs-pro-server-api@6.4.0': {}
 
   '@fingerprintjs/fingerprintjs-pro@3.11.6':
     dependencies:

--- a/projects/dotnet-sdk/dotnet-sdk.csproj
+++ b/projects/dotnet-sdk/dotnet-sdk.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FingerprintPro.ServerSdk" Version="7.2.0" />
+    <PackageReference Include="FingerprintPro.ServerSdk" Version="7.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/projects/go-sdk/go.mod
+++ b/projects/go-sdk/go.mod
@@ -2,4 +2,4 @@ module go-sdk
 
 go 1.23.0
 
-require github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0
+require github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.3.0

--- a/projects/go-sdk/go.sum
+++ b/projects/go-sdk/go.sum
@@ -1,9 +1,4 @@
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.1.2 h1:SShZriTpSem5rtjDhZnxXKx90cldzkr7Hswn+Jl1BFI=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.1.2/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0-test.0 h1:m6eiU1XUeHx/wwU1mV2oDb6BX7tWbE1E1/YnLCdUUPU=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0-test.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0-test.1 h1:5L8in8cxdQfD9X7q8+ZjnXRQUkGuEP+7cCL4cd141go=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0-test.1/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0-test.2 h1:nAQPeNi+KLWjVak8WCvPVXKP+XnVrbt1T5/e+r3hyOM=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0-test.2/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
+github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0 h1:8ee5wAVHeMBnnZ0CAisM9m4JsTtwm+9ci5URZdOKWXU=
 github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.2.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
+github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.3.0 h1:hp8CYZ+8C3Vd+EJofii7GdqgcBwsch7V8aWWwX9Ga24=
+github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.3.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=

--- a/projects/go-sdk/handlers/updateEvent.go
+++ b/projects/go-sdk/handlers/updateEvent.go
@@ -33,8 +33,10 @@ func UpdateEvent(w http.ResponseWriter, r *http.Request) {
 
 	updateBody := sdk.EventsUpdateRequest{
 		LinkedId: r.URL.Query().Get("linkedId"),
-		Tag:      &tag,
 		Suspect:  suspectValue,
+	}
+	if tag != nil {
+		updateBody.Tag = &tag
 	}
 
 	client, auth := utils.InitSdk(queryParams.ApiKey, queryParams.Region)

--- a/projects/java-sdk/build.gradle.kts
+++ b/projects/java-sdk/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-	implementation("com.github.fingerprintjs:fingerprint-pro-server-api-java-sdk:v7.3.0")
+	implementation("com.github.fingerprintjs:fingerprint-pro-server-api-java-sdk:v7.4.0")
 }
 
 tasks.withType<Test> {

--- a/projects/node-sdk/package.json
+++ b/projects/node-sdk/package.json
@@ -6,7 +6,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@fingerprintjs/fingerprintjs-pro-server-api": "^6.3.0",
+    "@fingerprintjs/fingerprintjs-pro-server-api": "^6.4.0",
     "express": "^5.0.1",
     "tslib": "^2.8.1",
     "ts-node": "^10.9.2"

--- a/projects/php-sdk/composer.json
+++ b/projects/php-sdk/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "fingerprint/fingerprint-pro-server-api-sdk": "6.3.0",
+    "fingerprint/fingerprint-pro-server-api-sdk": "6.4.0",
     "slim/slim": "^4.0"
   },
   "autoload": {

--- a/projects/php-sdk/composer.lock
+++ b/projects/php-sdk/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a06628311ae5d08cc5f2153adc16063",
+    "content-hash": "c2470e62f9d4549f3740d4de0e5e295b",
     "packages": [
         {
             "name": "fingerprint/fingerprint-pro-server-api-sdk",
-            "version": "6.3.0",
+            "version": "6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk.git",
-                "reference": "8fc29a99d51f03338011c2b100dbc4d81d68d1e2"
+                "reference": "99cc1e4a4bf28c7db6504450dbe52f61fb3f203f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fingerprintjs/fingerprint-pro-server-api-php-sdk/zipball/8fc29a99d51f03338011c2b100dbc4d81d68d1e2",
-                "reference": "8fc29a99d51f03338011c2b100dbc4d81d68d1e2",
+                "url": "https://api.github.com/repos/fingerprintjs/fingerprint-pro-server-api-php-sdk/zipball/99cc1e4a4bf28c7db6504450dbe52f61fb3f203f",
+                "reference": "99cc1e4a4bf28c7db6504450dbe52f61fb3f203f",
                 "shasum": ""
             },
             "require": {
@@ -72,22 +72,22 @@
             ],
             "support": {
                 "issues": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/issues",
-                "source": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/tree/v6.3.0"
+                "source": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/tree/v6.4.0"
             },
-            "time": "2025-03-17T15:42:06+00:00"
+            "time": "2025-04-02T13:24:19+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.2",
+            "version": "7.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "d281ed313b989f213357e3be1a179f02196ac99b"
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d281ed313b989f213357e3be1a179f02196ac99b",
-                "reference": "d281ed313b989f213357e3be1a179f02196ac99b",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
                 "shasum": ""
             },
             "require": {
@@ -184,7 +184,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
             },
             "funding": [
                 {
@@ -200,20 +200,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-24T11:22:20+00:00"
+            "time": "2025-03-27T13:37:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.4",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455"
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
-                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
                 "shasum": ""
             },
             "require": {
@@ -267,7 +267,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.4"
+                "source": "https://github.com/guzzle/promises/tree/2.2.0"
             },
             "funding": [
                 {
@@ -283,20 +283,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-17T10:06:22+00:00"
+            "time": "2025-03-27T13:27:01+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
                 "shasum": ""
             },
             "require": {
@@ -383,7 +383,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
             },
             "funding": [
                 {
@@ -399,7 +399,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-18T11:15:46+00:00"
+            "time": "2025-03-27T12:30:47+00:00"
         },
         {
             "name": "nikic/fast-route",

--- a/projects/python-sdk/requirements.txt
+++ b/projects/python-sdk/requirements.txt
@@ -1,2 +1,2 @@
-fingerprint_pro_server_api_sdk==8.4.0
+fingerprint_pro_server_api_sdk==8.5.0
 flask>=3.1


### PR DESCRIPTION

This pull request includes the following changes:
- Updated all projects to use the latest version of the SDK.
- Modified the Go SDK project to ensure the 'Tag' field in the update body is only assigned when the tag value is non-nil