### PR TITLE
chore: upgrade server SDKs to latest version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.11.6
         version: 3.11.6
       '@fingerprintjs/fingerprintjs-pro-server-api':
-        specifier: ^6.6.0
-        version: 6.6.0
+        specifier: ^6.7.0
+        version: 6.7.0
       '@playwright/test':
         specifier: ^1.49.1
         version: 1.49.1
@@ -36,8 +36,8 @@ importers:
   projects/node-sdk:
     dependencies:
       '@fingerprintjs/fingerprintjs-pro-server-api':
-        specifier: 6.6.0
-        version: 6.6.0
+        specifier: 6.7.0
+        version: 6.7.0
       express:
         specifier: ^5.0.1
         version: 5.0.1
@@ -90,8 +90,8 @@ packages:
     peerDependencies:
       prettier: '>=3'
 
-  '@fingerprintjs/fingerprintjs-pro-server-api@6.6.0':
-    resolution: {integrity: sha512-uJo9dZXMaga4jpcyQX4UIkUcin1eQDbMMXil+sYVNaZi2pQUj/C7OFi9KdRGaBQbXY7AnmZpjT3rirVsOBXmtg==}
+  '@fingerprintjs/fingerprintjs-pro-server-api@6.7.0':
+    resolution: {integrity: sha512-4YHct8AORwosLCDlJYU4LnqriIBj4M995xjeILNwASfkVITu4pMohHPVXuI0qG33hQopBoP/FkyQsEPlaTD9RA==}
     engines: {node: '>=18.17.0'}
 
   '@fingerprintjs/fingerprintjs-pro@3.11.6':
@@ -1102,7 +1102,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fingerprintjs/fingerprintjs-pro-server-api@6.6.0': {}
+  '@fingerprintjs/fingerprintjs-pro-server-api@6.7.0': {}
 
   '@fingerprintjs/fingerprintjs-pro@3.11.6':
     dependencies:

--- a/projects/conductor/package.json
+++ b/projects/conductor/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "description": "",
   "devDependencies": {
-    "@fingerprintjs/fingerprintjs-pro-server-api": "^6.6.0",
+    "@fingerprintjs/fingerprintjs-pro-server-api": "^6.7.0",
     "@fingerprintjs/fingerprintjs-pro": "^3.11.6",
     "@playwright/test": "^1.49.1",
     "@types/node": "^22.10.1",

--- a/projects/dotnet-sdk/dotnet-sdk.csproj
+++ b/projects/dotnet-sdk/dotnet-sdk.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FingerprintPro.ServerSdk" Version="7.5.0" />
+    <PackageReference Include="FingerprintPro.ServerSdk" Version="7.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/projects/go-sdk/go.mod
+++ b/projects/go-sdk/go.mod
@@ -2,4 +2,4 @@ module go-sdk
 
 go 1.23.0
 
-require github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.5.0
+require github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.6.0

--- a/projects/go-sdk/go.sum
+++ b/projects/go-sdk/go.sum
@@ -1,2 +1,4 @@
 github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.5.0 h1:SZAWtMeDrxbuW9G92DSDifsamWv0BYgVQOdBo7GEwrY=
 github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.5.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
+github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.6.0 h1:tpIBCSmN6Nh6WaxlHBWZLRRQgRZ45RWwpJvdWyugmdo=
+github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.6.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=

--- a/projects/java-sdk/build.gradle.kts
+++ b/projects/java-sdk/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-	implementation("com.github.fingerprintjs:fingerprint-pro-server-api-java-sdk:v7.6.0")
+	implementation("com.github.fingerprintjs:fingerprint-pro-server-api-java-sdk:v7.7.0")
 }
 
 tasks.withType<Test> {

--- a/projects/node-sdk/package.json
+++ b/projects/node-sdk/package.json
@@ -6,7 +6,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@fingerprintjs/fingerprintjs-pro-server-api": "6.6.0",
+    "@fingerprintjs/fingerprintjs-pro-server-api": "6.7.0",
     "express": "^5.0.1",
     "tslib": "^2.8.1",
     "ts-node": "^10.9.2"

--- a/projects/php-sdk/composer.json
+++ b/projects/php-sdk/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "fingerprint/fingerprint-pro-server-api-sdk": "6.6.0",
+    "fingerprint/fingerprint-pro-server-api-sdk": "6.7.0",
     "slim/slim": "^4.0"
   },
   "autoload": {

--- a/projects/php-sdk/composer.lock
+++ b/projects/php-sdk/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc51c3a42786574dc280447a2cccd2f8",
+    "content-hash": "2c8c075c649cf776de046f25d793500c",
     "packages": [
         {
             "name": "fingerprint/fingerprint-pro-server-api-sdk",
-            "version": "6.6.0",
+            "version": "6.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk.git",
-                "reference": "3757ac3a917c5728b8b8f47a58cdb597ff665bee"
+                "reference": "0ea2708b79c2d426bdf5d0f2fdc81395ee13dc74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fingerprintjs/fingerprint-pro-server-api-php-sdk/zipball/3757ac3a917c5728b8b8f47a58cdb597ff665bee",
-                "reference": "3757ac3a917c5728b8b8f47a58cdb597ff665bee",
+                "url": "https://api.github.com/repos/fingerprintjs/fingerprint-pro-server-api-php-sdk/zipball/0ea2708b79c2d426bdf5d0f2fdc81395ee13dc74",
+                "reference": "0ea2708b79c2d426bdf5d0f2fdc81395ee13dc74",
                 "shasum": ""
             },
             "require": {
@@ -72,9 +72,9 @@
             ],
             "support": {
                 "issues": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/issues",
-                "source": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/tree/v6.6.0"
+                "source": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/tree/v6.7.0"
             },
-            "time": "2025-06-04T13:11:13+00:00"
+            "time": "2025-07-09T13:57:44+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/projects/python-sdk/requirements.txt
+++ b/projects/python-sdk/requirements.txt
@@ -1,2 +1,2 @@
-fingerprint_pro_server_api_sdk==8.7.0
+fingerprint_pro_server_api_sdk==8.8.0
 flask>=3.1


### PR DESCRIPTION
The go SDK e2e tests will fail due to a known issue where the server API is always returning the optional `replayed` field. Discussion is ongoing on the appropriate resolution of these failures.