### PR TITLE
Distinguish v3 and v4 test run to make more clear which tests failed

### DIFF
--- a/.github/workflows/server-sdk-e2e-tests.yml
+++ b/.github/workflows/server-sdk-e2e-tests.yml
@@ -65,7 +65,8 @@ jobs:
     if: ${{ (github.event_name != 'workflow_dispatch' && github.event_name != 'repository_dispatch') || inputs.run-node-sdk-tests || github.event.client_payload.run-node-sdk-tests }}
     runs-on: ubuntu-latest
     outputs:
-      test_failed: ${{ steps.result.outputs.test_failed }}
+      v3_test_failed: ${{ steps.v3-result.outputs.test_failed }}
+      v4_test_failed: ${{ steps.v4-result.outputs.test_failed }}
     steps:
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
@@ -120,7 +121,8 @@ jobs:
           nohup pnpm start &
 
       # Run tests
-      - name: Run tests
+      - name: Run v4 tests
+        id: run-v4
         working-directory: ./projects/conductor
         env:
           MUSICIAN_PORT: 3002
@@ -137,11 +139,39 @@ jobs:
           MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
           DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
           DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
-        run: pnpm playwright test
+        run: pnpm playwright test --project="chromium v4"
 
-      - name: Set test result on failure
-        id: result
-        if: failure()
+      - name: Set v4 test result on failure
+        id: v4-result
+        if: always() && steps.run-v4.outcome == 'failure'
+        run: echo "test_failed=true" >> $GITHUB_OUTPUT
+
+      # Run v3 tests regardless of v4 outcome, but only if v4 actually ran.
+      # This ensures v3 is skipped if an earlier setup step (e.g. checkout, install) failed.
+      - name: Run v3 tests
+        id: run-v3
+        if: always() && (steps.run-v4.outcome == 'success' || steps.run-v4.outcome == 'failure')
+        working-directory: ./projects/conductor
+        env:
+          MUSICIAN_PORT: 3002
+          MINIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MINIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MINIMUM_US_SEALED_PUBLIC_KEY }}
+          MINIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MINIMUM_US_SEALED_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MINIMUM_US_SEALED_ENCRYPTION_KEY }}
+          MAXIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MAXIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_SEALED_PUBLIC_KEY }}
+          MAXIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_SEALED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
+          DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
+          DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
+        run: pnpm playwright test --project="chromium v3"
+
+      - name: Set v3 test result on failure
+        id: v3-result
+        if: always() && steps.run-v3.outcome == 'failure'
         run: echo "test_failed=true" >> $GITHUB_OUTPUT
 
       - name: Set failed status
@@ -173,7 +203,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     outputs:
-      test_failed: ${{ steps.result.outputs.test_failed }}
+      v3_test_failed: ${{ steps.v3-result.outputs.test_failed }}
+      v4_test_failed: ${{ steps.v4-result.outputs.test_failed }}
     steps:
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
@@ -246,7 +277,8 @@ jobs:
         run: |
           nohup java -jar build/libs/*-SNAPSHOT.jar &
 
-      - name: Run tests
+      - name: Run v4 tests
+        id: run-v4
         working-directory: ./projects/conductor
         env:
           MUSICIAN_PORT: 8080
@@ -263,11 +295,39 @@ jobs:
           MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
           DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
           DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
-        run: pnpm playwright test
+        run: pnpm playwright test --project="chromium v4"
 
-      - name: Set test result on failure
-        id: result
-        if: failure()
+      - name: Set v4 test result on failure
+        id: v4-result
+        if: always() && steps.run-v4.outcome == 'failure'
+        run: echo "test_failed=true" >> $GITHUB_OUTPUT
+
+      # Run v3 tests regardless of v4 outcome, but only if v4 actually ran.
+      # This ensures v3 is skipped if an earlier setup step (e.g. checkout, install) failed.
+      - name: Run v3 tests
+        id: run-v3
+        if: always() && (steps.run-v4.outcome == 'success' || steps.run-v4.outcome == 'failure')
+        working-directory: ./projects/conductor
+        env:
+          MUSICIAN_PORT: 8080
+          MINIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MINIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MINIMUM_US_SEALED_PUBLIC_KEY }}
+          MINIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MINIMUM_US_SEALED_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MINIMUM_US_SEALED_ENCRYPTION_KEY }}
+          MAXIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MAXIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_SEALED_PUBLIC_KEY }}
+          MAXIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_SEALED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
+          DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
+          DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
+        run: pnpm playwright test --project="chromium v3"
+
+      - name: Set v3 test result on failure
+        id: v3-result
+        if: always() && steps.run-v3.outcome == 'failure'
         run: echo "test_failed=true" >> $GITHUB_OUTPUT
 
       - name: Set failed status
@@ -299,7 +359,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     outputs:
-      test_failed: ${{ steps.result.outputs.test_failed }}
+      v3_test_failed: ${{ steps.v3-result.outputs.test_failed }}
+      v4_test_failed: ${{ steps.v4-result.outputs.test_failed }}
     steps:
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
@@ -366,7 +427,8 @@ jobs:
         run: |
           nohup dotnet ./out/dotnet-sdk.dll &
 
-      - name: Run tests
+      - name: Run v4 tests
+        id: run-v4
         working-directory: ./projects/conductor
         env:
           MUSICIAN_PORT: 5243
@@ -383,11 +445,39 @@ jobs:
           MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
           DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
           DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
-        run: pnpm playwright test
+        run: pnpm playwright test --project="chromium v4"
 
-      - name: Set test result on failure
-        id: result
-        if: failure()
+      - name: Set v4 test result on failure
+        id: v4-result
+        if: always() && steps.run-v4.outcome == 'failure'
+        run: echo "test_failed=true" >> $GITHUB_OUTPUT
+
+      # Run v3 tests regardless of v4 outcome, but only if v4 actually ran.
+      # This ensures v3 is skipped if an earlier setup step (e.g. checkout, install) failed.
+      - name: Run v3 tests
+        id: run-v3
+        if: always() && (steps.run-v4.outcome == 'success' || steps.run-v4.outcome == 'failure')
+        working-directory: ./projects/conductor
+        env:
+          MUSICIAN_PORT: 5243
+          MINIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MINIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MINIMUM_US_SEALED_PUBLIC_KEY }}
+          MINIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MINIMUM_US_SEALED_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MINIMUM_US_SEALED_ENCRYPTION_KEY }}
+          MAXIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MAXIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_SEALED_PUBLIC_KEY }}
+          MAXIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_SEALED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
+          DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
+          DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
+        run: pnpm playwright test --project="chromium v3"
+
+      - name: Set v3 test result on failure
+        id: v3-result
+        if: always() && steps.run-v3.outcome == 'failure'
         run: echo "test_failed=true" >> $GITHUB_OUTPUT
 
       - name: Set failed status
@@ -419,7 +509,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     outputs:
-      test_failed: ${{ steps.result.outputs.test_failed }}
+      v3_test_failed: ${{ steps.v3-result.outputs.test_failed }}
+      v4_test_failed: ${{ steps.v4-result.outputs.test_failed }}
     steps:
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
@@ -498,7 +589,8 @@ jobs:
         run: |
           nohup ./myapp &
 
-      - name: Run tests
+      - name: Run v4 tests
+        id: run-v4
         working-directory: ./projects/conductor
         env:
           MUSICIAN_PORT: 8081
@@ -515,11 +607,39 @@ jobs:
           MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
           DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
           DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
-        run: pnpm playwright test
+        run: pnpm playwright test --project="chromium v4"
 
-      - name: Set test result on failure
-        id: result
-        if: failure()
+      - name: Set v4 test result on failure
+        id: v4-result
+        if: always() && steps.run-v4.outcome == 'failure'
+        run: echo "test_failed=true" >> $GITHUB_OUTPUT
+
+      # Run v3 tests regardless of v4 outcome, but only if v4 actually ran.
+      # This ensures v3 is skipped if an earlier setup step (e.g. checkout, install) failed.
+      - name: Run v3 tests
+        id: run-v3
+        if: always() && (steps.run-v4.outcome == 'success' || steps.run-v4.outcome == 'failure')
+        working-directory: ./projects/conductor
+        env:
+          MUSICIAN_PORT: 8081
+          MINIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MINIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MINIMUM_US_SEALED_PUBLIC_KEY }}
+          MINIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MINIMUM_US_SEALED_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MINIMUM_US_SEALED_ENCRYPTION_KEY }}
+          MAXIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MAXIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_SEALED_PUBLIC_KEY }}
+          MAXIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_SEALED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
+          DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
+          DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
+        run: pnpm playwright test --project="chromium v3"
+
+      - name: Set v3 test result on failure
+        id: v3-result
+        if: always() && steps.run-v3.outcome == 'failure'
         run: echo "test_failed=true" >> $GITHUB_OUTPUT
 
       - name: Set failed status
@@ -551,7 +671,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     outputs:
-      test_failed: ${{ steps.result.outputs.test_failed }}
+      v3_test_failed: ${{ steps.v3-result.outputs.test_failed }}
+      v4_test_failed: ${{ steps.v4-result.outputs.test_failed }}
     steps:
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
@@ -615,7 +736,8 @@ jobs:
         run: |
           nohup python main.py &
 
-      - name: Run tests
+      - name: Run v4 tests
+        id: run-v4
         working-directory: ./projects/conductor
         env:
           MUSICIAN_PORT: 3003
@@ -632,11 +754,39 @@ jobs:
           MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
           DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
           DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
-        run: pnpm playwright test
+        run: pnpm playwright test --project="chromium v4"
 
-      - name: Set test result on failure
-        id: result
-        if: failure()
+      - name: Set v4 test result on failure
+        id: v4-result
+        if: always() && steps.run-v4.outcome == 'failure'
+        run: echo "test_failed=true" >> $GITHUB_OUTPUT
+
+      # Run v3 tests regardless of v4 outcome, but only if v4 actually ran.
+      # This ensures v3 is skipped if an earlier setup step (e.g. checkout, install) failed.
+      - name: Run v3 tests
+        id: run-v3
+        if: always() && (steps.run-v4.outcome == 'success' || steps.run-v4.outcome == 'failure')
+        working-directory: ./projects/conductor
+        env:
+          MUSICIAN_PORT: 3003
+          MINIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MINIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MINIMUM_US_SEALED_PUBLIC_KEY }}
+          MINIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MINIMUM_US_SEALED_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MINIMUM_US_SEALED_ENCRYPTION_KEY }}
+          MAXIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MAXIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_SEALED_PUBLIC_KEY }}
+          MAXIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_SEALED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
+          DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
+          DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
+        run: pnpm playwright test --project="chromium v3"
+
+      - name: Set v3 test result on failure
+        id: v3-result
+        if: always() && steps.run-v3.outcome == 'failure'
         run: echo "test_failed=true" >> $GITHUB_OUTPUT
 
       - name: Set failed status
@@ -668,7 +818,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     outputs:
-      test_failed: ${{ steps.result.outputs.test_failed }}
+      v3_test_failed: ${{ steps.v3-result.outputs.test_failed }}
+      v4_test_failed: ${{ steps.v4-result.outputs.test_failed }}
     steps:
       - name: 'Get token for the GitHub App'
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
@@ -741,7 +892,8 @@ jobs:
         run: |
           nohup php -S 0.0.0.0:3004 -t public/ &
 
-      - name: Run tests
+      - name: Run v4 tests
+        id: run-v4
         working-directory: ./projects/conductor
         env:
           MUSICIAN_PORT: 3004
@@ -758,11 +910,39 @@ jobs:
           MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
           DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
           DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
-        run: pnpm playwright test
+        run: pnpm playwright test --project="chromium v4"
 
-      - name: Set test result on failure
-        id: result
-        if: failure()
+      - name: Set v4 test result on failure
+        id: v4-result
+        if: always() && steps.run-v4.outcome == 'failure'
+        run: echo "test_failed=true" >> $GITHUB_OUTPUT
+
+      # Run v3 tests regardless of v4 outcome, but only if v4 actually ran.
+      # This ensures v3 is skipped if an earlier setup step (e.g. checkout, install) failed.
+      - name: Run v3 tests
+        id: run-v3
+        if: always() && (steps.run-v4.outcome == 'success' || steps.run-v4.outcome == 'failure')
+        working-directory: ./projects/conductor
+        env:
+          MUSICIAN_PORT: 3004
+          MINIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MINIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MINIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MINIMUM_US_SEALED_PUBLIC_KEY }}
+          MINIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MINIMUM_US_SEALED_PRIVATE_KEY }}
+          MINIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MINIMUM_US_SEALED_ENCRYPTION_KEY }}
+          MAXIMUM_US_DEFAULT_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PUBLIC_KEY }}
+          MAXIMUM_US_DEFAULT_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_PRIVATE_KEY }}
+          MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_DEFAULT_DELETED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_PUBLIC_KEY: ${{ secrets.MAXIMUM_US_SEALED_PUBLIC_KEY }}
+          MAXIMUM_US_SEALED_PRIVATE_KEY: ${{ secrets.MAXIMUM_US_SEALED_PRIVATE_KEY }}
+          MAXIMUM_US_SEALED_ENCRYPTION_KEY: ${{ secrets.MAXIMUM_US_SEALED_ENCRYPTION_KEY }}
+          DEFAULT_EU_DEFAULT_PUBLIC_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PUBLIC_KEY }}
+          DEFAULT_EU_DEFAULT_PRIVATE_KEY: ${{ secrets.DEFAULT_EU_DEFAULT_PRIVATE_KEY }}
+        run: pnpm playwright test --project="chromium v3"
+
+      - name: Set v3 test result on failure
+        id: v3-result
+        if: always() && steps.run-v3.outcome == 'failure'
         run: echo "test_failed=true" >> $GITHUB_OUTPUT
 
       - name: Set failed status
@@ -803,33 +983,58 @@ jobs:
       - name: Checks the statuses from each job
         run: |
           failed=false
-          if [ "${{ needs.run-node-sdk-tests.outputs.test_failed }}" = "true" ]; then
-            echo "Node SDK tests failed"
+
+          if [ "${{ needs.run-node-sdk-tests.outputs.v3_test_failed }}" = "true" ]; then
+            echo "Node SDK v3 tests failed"
+            failed=true
+          fi
+          if [ "${{ needs.run-node-sdk-tests.outputs.v4_test_failed }}" = "true" ]; then
+            echo "Node SDK v4 tests failed"
             failed=true
           fi
 
-          if [ "${{ needs.run-java-sdk-tests.outputs.test_failed }}" = "true" ]; then
-            echo "Java SDK tests failed"
+          if [ "${{ needs.run-java-sdk-tests.outputs.v3_test_failed }}" = "true" ]; then
+            echo "Java SDK v3 tests failed"
+            failed=true
+          fi
+          if [ "${{ needs.run-java-sdk-tests.outputs.v4_test_failed }}" = "true" ]; then
+            echo "Java SDK v4 tests failed"
             failed=true
           fi
 
-          if [ "${{ needs.run-dotnet-sdk-tests.outputs.test_failed }}" = "true" ]; then
-            echo ".NET SDK tests failed"
+          if [ "${{ needs.run-dotnet-sdk-tests.outputs.v3_test_failed }}" = "true" ]; then
+            echo ".NET SDK v3 tests failed"
+            failed=true
+          fi
+          if [ "${{ needs.run-dotnet-sdk-tests.outputs.v4_test_failed }}" = "true" ]; then
+            echo ".NET SDK v4 tests failed"
             failed=true
           fi
 
-          if [ "${{ needs.run-go-sdk-tests.outputs.test_failed }}" = "true" ]; then
-            echo "Go SDK tests failed"
+          if [ "${{ needs.run-go-sdk-tests.outputs.v3_test_failed }}" = "true" ]; then
+            echo "Go SDK v3 tests failed"
+            failed=true
+          fi
+          if [ "${{ needs.run-go-sdk-tests.outputs.v4_test_failed }}" = "true" ]; then
+            echo "Go SDK v4 tests failed"
             failed=true
           fi
 
-          if [ "${{ needs.run-python-sdk-tests.outputs.test_failed }}" = "true" ]; then
-            echo "Python SDK tests failed"
+          if [ "${{ needs.run-python-sdk-tests.outputs.v3_test_failed }}" = "true" ]; then
+            echo "Python SDK v3 tests failed"
+            failed=true
+          fi
+          if [ "${{ needs.run-python-sdk-tests.outputs.v4_test_failed }}" = "true" ]; then
+            echo "Python SDK v4 tests failed"
             failed=true
           fi
 
-          if [ "${{ needs.run-php-sdk-tests.outputs.test_failed }}" = "true" ]; then
-            echo "PHP SDK tests failed"
+          if [ "${{ needs.run-php-sdk-tests.outputs.v3_test_failed }}" = "true" ]; then
+            echo "PHP SDK v3 tests failed"
+            failed=true
+          fi
+          if [ "${{ needs.run-php-sdk-tests.outputs.v4_test_failed }}" = "true" ]; then
+            echo "PHP SDK v4 tests failed"
             failed=true
           fi
 

--- a/projects/conductor/utils/api.ts
+++ b/projects/conductor/utils/api.ts
@@ -1,4 +1,4 @@
-import { APIRequestContext, expect } from '@playwright/test'
+import { APIRequestContext } from '@playwright/test'
 import testData from './testData'
 import { jsonRequest, JsonResponse, RequestParams } from './http'
 import { MusicianResponse } from './musician'

--- a/projects/conductor/utils/api.ts
+++ b/projects/conductor/utils/api.ts
@@ -375,17 +375,3 @@ export class RealFingerprintApi implements FingerprintApi {
     })
   }
 }
-
-/**
- * @deprecated Use RealFingerprintApi.getEvent instead
- * */
-export async function getEvent(request: APIRequestContext, requestId: string, apiKey: string) {
-  const getEventByRequestID = await request.get(`${testData.config.apiUrl}/events/${requestId}`, {
-    headers: {
-      'Auth-API-Key': apiKey,
-      'content-type': 'application/json',
-    },
-  })
-  expect(getEventByRequestID.status()).toEqual(200)
-  return getEventByRequestID.json()
-}

--- a/projects/conductor/utils/http.ts
+++ b/projects/conductor/utils/http.ts
@@ -77,8 +77,8 @@ export async function jsonRequest<T = any>({
   }
 
   const response = await request[method](finalUrl, args)
+  const text = await response.text()
   if (!response.ok()) {
-    const text = await response.text()
     console.error(`Request to ${finalUrl} failed with status ${response.status()}`, {
       params,
       method,
@@ -88,5 +88,5 @@ export async function jsonRequest<T = any>({
     throw new Error(`Request failed with status ${response.status()} | Response Text: ${text}`)
   }
 
-  return { data: await response.json(), response }
+  return { data: (text ? JSON.parse(text) : undefined) as T, response }
 }

--- a/projects/conductor/utils/http.ts
+++ b/projects/conductor/utils/http.ts
@@ -5,7 +5,7 @@ export type RequestParams = Record<string, Primitive | Primitive[]>
 
 type MethodVariants =
   | { method?: 'get'; params?: RequestParams }
-  | { method: 'post'; params?: any; data?: unknown }
+  | { method: 'post' | 'patch'; params?: any; data?: unknown }
   | { method: 'delete'; params?: any }
 
 type JsonRequestOptions = {

--- a/projects/conductor/utils/http.ts
+++ b/projects/conductor/utils/http.ts
@@ -5,8 +5,7 @@ export type RequestParams = Record<string, Primitive | Primitive[]>
 
 type MethodVariants =
   | { method?: 'get'; params?: RequestParams }
-  | { method: 'post' | 'patch'; params?: any; data?: unknown }
-  | { method: 'delete'; params?: any }
+  | { method: 'post' | 'patch'| 'delete'; params?: any }
 
 type JsonRequestOptions = {
   request: APIRequestContext
@@ -72,7 +71,7 @@ export async function jsonRequest<T = any>({
     if (queryString) {
       finalUrl = url.includes('?') ? `${url}&${queryString}` : `${url}?${queryString}`
     }
-  } else if (method === 'post') {
+  } else if (['post', 'patch'].includes(method)) {
     args.data = params
   }
 

--- a/projects/conductor/utils/v4/api.ts
+++ b/projects/conductor/utils/v4/api.ts
@@ -104,7 +104,7 @@ export class RealFingerprintV4Api implements FingerprintV4Api {
     return await jsonRequest<void>({
       request: this.request,
       url: `${this.baseURL}/events/${event_id}`,
-      data,
+      params: data,
       method: 'patch',
       headers: {
         Authorization: `Bearer ${api_key}`,

--- a/projects/conductor/utils/v4/api.ts
+++ b/projects/conductor/utils/v4/api.ts
@@ -105,6 +105,7 @@ export class RealFingerprintV4Api implements FingerprintV4Api {
       request: this.request,
       url: `${this.baseURL}/events/${event_id}`,
       data,
+      method: 'patch',
       headers: {
         Authorization: `Bearer ${api_key}`,
         'content-type': 'application/json',

--- a/projects/go-sdk/go.mod
+++ b/projects/go-sdk/go.mod
@@ -2,6 +2,6 @@ module go-sdk
 
 go 1.23.0
 
-require github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.9.0
+require github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.10.0
 
-require github.com/fingerprintjs/go-sdk/v8 v8.0.0-test.5 // indirect
+require github.com/fingerprintjs/go-sdk/v8 v8.1.0

--- a/projects/go-sdk/go.sum
+++ b/projects/go-sdk/go.sum
@@ -1,10 +1,4 @@
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.8.0 h1:pD2BQiOMbWAmQxkCOSWmnEc5MVTqv6MtbLnprFemC9o=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.8.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.9.0-test.0 h1:J9vaQM+/RYQ926eL0S03QaaDkaPv0IwXRw7S1cbB7X8=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.9.0-test.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.9.0-test.1 h1:mCdtJY1e39Vb+5pyQPGuMD6SGoypshb6eNwgsZaAJPg=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.9.0-test.1/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.9.0 h1:Cc0WFXoSluyDwbCu9O0pOlUKQPKEhrzw4l+Vx/VmAHE=
-github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.9.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
-github.com/fingerprintjs/go-sdk/v8 v8.0.0-test.5 h1:Fjl9rCL6PKyK7GvCGzHj/Ip9CK/v2TkSs7Xc8kGrnhA=
-github.com/fingerprintjs/go-sdk/v8 v8.0.0-test.5/go.mod h1:keVuTTvDofQYjzm6t+YXPZ9twIIk4UzpXOoXhJhjySc=
+github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.10.0 h1:1BzzOkZn1Fja/1IHDIGQ9yRNGsqSTFsSmEAtrwnnkbQ=
+github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.10.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
+github.com/fingerprintjs/go-sdk/v8 v8.1.0 h1:4rjCO6RtMZ7YIX7zIGgp/cAfltzwGNY50LrY/d8R2Oo=
+github.com/fingerprintjs/go-sdk/v8 v8.1.0/go.mod h1:keVuTTvDofQYjzm6t+YXPZ9twIIk4UzpXOoXhJhjySc=


### PR DESCRIPTION
 - Split v3/v4 test runs into separate CI steps with independent outputs (`v3_test_failed` / `v4_test_failed`) — previously both versions ran as one step, making it  impossible to tell which SDK version caused a failure                                                                                                           
  - Fixed `updateEvent` in v4 API sending a GET instead of PATCH — `method: 'patch'` was missing from the `jsonRequest` call, and `patch` wasn't included in the `MethodVariants` type                                                                                                                                             
  - Fixed crash when parsing empty response body — `deleteVisitor` and `updateEvent` return no body on success, which caused response.json() to throw; now reads body as text first and only parses if non-empty                                                                                                                      
  - Removed deprecated standalone `getEvent` function for v3 requests that was already replaced by `RealFingerprintApi.getEvent`
