### PR TITLE
test: add test coverage for new query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,5 +300,5 @@ There are two supported ways to bump Server SDK versions: via the helper script 
 
    ```shell
    cd projects/php-sdk
-   composer require fingerprint/fingerprint-pro-server-api-sdk:<version> --update-with-dependencies
+   composer require fingerprint/server-sdk:<version> --update-with-dependencies
    ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
   projects/node-sdk:
     dependencies:
       '@fingerprint/node-sdk':
-        specifier: ^7.1.0
-        version: 7.1.0
+        specifier: 7.3.0-test.0
+        version: 7.3.0-test.0
       '@fingerprintjs/fingerprintjs-pro-server-api':
         specifier: 6.11.0
         version: 6.11.0
@@ -105,6 +105,10 @@ packages:
 
   '@fingerprint/node-sdk@7.1.0':
     resolution: {integrity: sha512-qt2Tc+s7yFJQQKmjOAJPVWi3gItr1UynnpVg2iCbgwwquNYtqOZ81OIR+nu6erVonrY8uYhdnoSoUwq5K6li0Q==}
+    engines: {node: '>=18.17.0'}
+
+  '@fingerprint/node-sdk@7.3.0-test.0':
+    resolution: {integrity: sha512-42U8P9R5wkRrx9d53+6MXfOSzvuX36cLmTkxCnx8hpqtMBeC14aJgefXY7YT+z2bbFIc6CsflaQZpwEeXz0NTA==}
     engines: {node: '>=18.17.0'}
 
   '@fingerprintjs/eslint-config-dx-team@0.1.0':
@@ -1119,6 +1123,8 @@ snapshots:
   '@fingerprint/agent@4.0.1': {}
 
   '@fingerprint/node-sdk@7.1.0': {}
+
+  '@fingerprint/node-sdk@7.3.0-test.0': {}
 
   '@fingerprintjs/eslint-config-dx-team@0.1.0(prettier@3.8.1)(typescript@5.6.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       '@fingerprint/node-sdk':
-        specifier: ^7.1.0
-        version: 7.1.0
+        specifier: 7.3.0-test.0
+        version: 7.3.0-test.0
       '@fingerprintjs/fingerprintjs-pro':
         specifier: ^3.11.6
         version: 3.11.6
@@ -102,10 +102,6 @@ packages:
 
   '@fingerprint/agent@4.0.1':
     resolution: {integrity: sha512-8+XUD3vP60Q5wpunaf932kp1lW2xWyXgI7f50EDAjoVNaNB7Y4T9qKam19y3WkgbipXnLdmekvNGtxEeyF+r9A==}
-
-  '@fingerprint/node-sdk@7.1.0':
-    resolution: {integrity: sha512-qt2Tc+s7yFJQQKmjOAJPVWi3gItr1UynnpVg2iCbgwwquNYtqOZ81OIR+nu6erVonrY8uYhdnoSoUwq5K6li0Q==}
-    engines: {node: '>=18.17.0'}
 
   '@fingerprint/node-sdk@7.3.0-test.0':
     resolution: {integrity: sha512-42U8P9R5wkRrx9d53+6MXfOSzvuX36cLmTkxCnx8hpqtMBeC14aJgefXY7YT+z2bbFIc6CsflaQZpwEeXz0NTA==}
@@ -1121,8 +1117,6 @@ snapshots:
   '@eslint/js@8.56.0': {}
 
   '@fingerprint/agent@4.0.1': {}
-
-  '@fingerprint/node-sdk@7.1.0': {}
 
   '@fingerprint/node-sdk@7.3.0-test.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ packages:
   - 'projects/*'
 
 minimumReleaseAgeExclude:
-  '@fingerprintjs/node-sdk@*'
+  '@fingerprint/node-sdk@*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   # all packages in direct subdirs of projects/
   - 'projects/*'
+
+minimumReleaseAgeExclude:
+  '@fingerprintjs/node-sdk@*'

--- a/projects/conductor/package.json
+++ b/projects/conductor/package.json
@@ -10,7 +10,7 @@
   "description": "",
   "devDependencies": {
     "@fingerprint/agent": "^4.0.1",
-    "@fingerprint/node-sdk": "^7.1.0",
+    "@fingerprint/node-sdk": "7.3.0-test.0",
     "@fingerprintjs/fingerprintjs-pro": "^3.11.6",
     "@fingerprintjs/fingerprintjs-pro-server-api": "6.11.0",
     "@playwright/test": "^1.58.2",

--- a/projects/conductor/tests/v4/004-searchEvents.test.ts
+++ b/projects/conductor/tests/v4/004-searchEvents.test.ts
@@ -1,5 +1,5 @@
 import { test } from '../../utils/v4/playwright'
-import testData from '../../utils/testData'
+import testData, { supportsStartEndDateTime } from '../../utils/testData'
 import { expect } from '@playwright/test'
 import { delay } from '../../utils/delay'
 import { SearchEventsFilter } from '@fingerprint/node-sdk'
@@ -209,6 +209,12 @@ test.describe('SearchEvents suite', () => {
     const bundleId = event.bundle_id || undefined
     const torNode = event.ip_blocklist.tor_node || undefined
     const packageName = event.package_name || undefined
+    const botInfo = event.bot_info ? 'all' : undefined
+    const botInfoCategory = event.bot_info?.category ? [event.bot_info.category] : undefined
+    const botInfoIdentity = event.bot_info?.identity ? [event.bot_info.identity] : undefined
+    const botInfoConfidence = event.bot_info?.confidence ? [event.bot_info.confidence] : undefined
+    const botInfoProvider = event.bot_info?.provider ? [event.bot_info.provider] : undefined
+    const botInfoName = event.bot_info?.name ? [event.bot_info.name] : undefined
 
     const result = await sdkApi.searchEvents({
       api_key: testData.credentials.maxFeaturesUS.privateKey,
@@ -250,6 +256,12 @@ test.describe('SearchEvents suite', () => {
       bundle_id: bundleId,
       tor_node: torNode,
       package_name: packageName,
+      bot_info: botInfo,
+      bot_info_category: botInfoCategory,
+      bot_info_identity: botInfoIdentity,
+      bot_info_confidence: botInfoConfidence,
+      bot_info_provider: botInfoProvider,
+      bot_info_name: botInfoName,
     })
 
     await assert.thatResponseMatch({
@@ -413,6 +425,27 @@ test.describe('SearchEvents suite', () => {
     })
 
     expect(dataWithFilter.events).toHaveLength(1)
+    expect(dataWithFilter.events[0].linked_id).toBe(linkedId)
+
+    if (supportsStartEndDateTime()) {
+      const { data: dataWithFilter } = await sdkApi.searchEvents({
+        limit: 2,
+        visitor_id: event.identification.visitor_id,
+        api_key: testData.credentials.maxFeaturesUS.privateKey,
+        region: testData.credentials.maxFeaturesUS.region,
+        // If start_date_time and end_date_time are supported, it is expected that the
+        // test app will give them higher precedence. If they aren't supported correctly,
+        // this time period will not return any events.
+        start: event.timestamp - 1000,
+        end: event.timestamp - 500,
+        start_date_time: new Date(event.timestamp - 10).toISOString(),
+        end_date_time: new Date(event.timestamp + 10).toISOString(),
+        linked_id: linkedId,
+      })
+
+      expect(dataWithFilter.events).toHaveLength(1)
+      expect(dataWithFilter.events[0].linked_id).toBe(linkedId)
+    }
   })
 
   test('with invalid token', async ({ assert }) => {

--- a/projects/conductor/tests/v4/004-searchEvents.test.ts
+++ b/projects/conductor/tests/v4/004-searchEvents.test.ts
@@ -420,7 +420,7 @@ test.describe('SearchEvents suite', () => {
       api_key: testData.credentials.maxFeaturesUS.privateKey,
       region: testData.credentials.maxFeaturesUS.region,
       start: event.timestamp - 10,
-      end: event.timestamp + 10,
+      end: supportsStartEndDateTime() ? event.timestamp + 10 : new Date(event.timestamp + 10).toISOString(),
       linked_id: linkedId,
     })
 

--- a/projects/conductor/utils/testData.ts
+++ b/projects/conductor/utils/testData.ts
@@ -212,4 +212,32 @@ export const testData = {
   },
 }
 
+const DEFAULT_MUSICIAN_PORTS_MAP: Record<string, string> = {
+  '3002': 'node',
+  '8080': 'java',
+  '5243': 'dotnet',
+  '8081': 'go',
+  '3004': 'php',
+  '3003': 'python',
+}
+
+export function supportsStartEndDateTime(): boolean {
+  const musicianPort = process.env.MUSICIAN_PORT
+  if (musicianPort) {
+    const sdk = DEFAULT_MUSICIAN_PORTS_MAP[musicianPort]
+    if (sdk) {
+      switch (sdk) {
+        case 'java':
+        case 'go':
+        case 'dotnet':
+          return true
+        default:
+          break
+      }
+    }
+  }
+
+  return false
+}
+
 export default testData

--- a/projects/conductor/utils/v4/api.ts
+++ b/projects/conductor/utils/v4/api.ts
@@ -25,6 +25,16 @@ export type DeleteVisitorParams = {
 export type SearchEventsParams = SearchEventsFilter & {
   api_key?: string
   region?: string
+  start_date_time?: string
+  end_date_time?: string
+} & {
+  // TODO remove after the next release of the node SDK
+  bot_info?: string
+  bot_info_category?: string[]
+  bot_info_identity?: string[]
+  bot_info_confidence?: string[]
+  bot_info_provider?: string[]
+  bot_info_name?: string[]
 }
 
 export type GetEventsParams = { api_key: string; region: string; event_id: string }

--- a/projects/conductor/utils/v4/api.ts
+++ b/projects/conductor/utils/v4/api.ts
@@ -27,14 +27,6 @@ export type SearchEventsParams = SearchEventsFilter & {
   region?: string
   start_date_time?: string
   end_date_time?: string
-} & {
-  // TODO remove after the next release of the node SDK
-  bot_info?: string
-  bot_info_category?: string[]
-  bot_info_identity?: string[]
-  bot_info_confidence?: string[]
-  bot_info_provider?: string[]
-  bot_info_name?: string[]
 }
 
 export type GetEventsParams = { api_key: string; region: string; event_id: string }

--- a/projects/dotnet-sdk/Controllers/V4/EventsController.cs
+++ b/projects/dotnet-sdk/Controllers/V4/EventsController.cs
@@ -82,7 +82,15 @@ public class EventsController(FingerprintV4Factory factory) : ControllerBase
         [FromQuery(Name = "origin")] string? origin,
         [FromQuery(Name = "bundle_id")] string? bundleId,
         [FromQuery(Name = "tor_node")] bool? torNode,
-        [FromQuery(Name = "package_name")] string? packageName
+        [FromQuery(Name = "package_name")] string? packageName,
+        [FromQuery(Name = "bot_info")] string? botInfo,
+        [FromQuery(Name = "bot_info_category")] List<string>? botInfoCategory,
+        [FromQuery(Name = "bot_info_identity")] List<string>? botInfoIdentity,
+        [FromQuery(Name = "bot_info_confidence")] List<string>? botInfoConfidence,
+        [FromQuery(Name = "bot_info_provider")] List<string>? botInfoProvider,
+        [FromQuery(Name = "bot_info_name")] List<string>? botInfoName,
+        [FromQuery(Name = "start_date_time")] DateTime? startDateTime,
+        [FromQuery(Name = "end_date_time")] DateTime? endDateTime
     )
     {
         try
@@ -96,7 +104,9 @@ public class EventsController(FingerprintV4Factory factory) : ControllerBase
             if (linkedId != null) request = request.WithLinkedId(linkedId);
             if (ipAddress != null) request = request.WithIpAddress(ipAddress);
             if (start.HasValue) request = request.WithStart(start.Value);
+            if (startDateTime.HasValue) request = request.WithStartDateTime(startDateTime.Value);
             if (end.HasValue) request = request.WithEnd(end.Value);
+            if (endDateTime.HasValue) request = request.WithEndDateTime(endDateTime.Value);
             if (reverse.HasValue) request = request.WithReverse(reverse.Value);
             if (suspect.HasValue) request = request.WithSuspect(suspect.Value);
             if (vpn.HasValue) request = request.WithVpn(vpn.Value);
@@ -122,6 +132,28 @@ public class EventsController(FingerprintV4Factory factory) : ControllerBase
                 try { request = request.WithBot(SearchEventsBotValueConverter.FromString(bot)); }
                 catch { throw new ApiException("Invalid bot filter", HttpStatusCode.BadRequest, "{\"error\":{\"code\":\"request_cannot_be_parsed\",\"message\":\"invalid bot type\"}}"); }
             }
+            if (botInfo != null)
+            {
+                try { request = request.WithBotInfo(SearchEventsBotInfoValueConverter.FromString(botInfo)); }
+                catch { throw new ApiException("Invalid bot_info filter", HttpStatusCode.BadRequest, "{\"error\":{\"code\":\"request_cannot_be_parsed\",\"message\":\"invalid bot info\"}}"); }
+            }
+            if (botInfoCategory is { Count: > 0 })
+            {
+                try { request = request.WithBotInfoCategory(botInfoCategory.Select(BotInfoCategoryValueConverter.FromString).ToList()); }
+                catch { throw new ApiException("Invalid bot_info_category filter", HttpStatusCode.BadRequest, "{\"error\":{\"code\":\"request_cannot_be_parsed\",\"message\":\"invalid bot info category\"}}"); }
+            }
+            if (botInfoIdentity is { Count: > 0 })
+            {
+                try { request = request.WithBotInfoIdentity(botInfoIdentity.Select(BotInfoIdentityValueConverter.FromString).ToList()); }
+                catch { throw new ApiException("Invalid bot_info_identity filter", HttpStatusCode.BadRequest, "{\"error\":{\"code\":\"request_cannot_be_parsed\",\"message\":\"invalid bot info identity\"}}"); }
+            }
+            if (botInfoConfidence is { Count: > 0 })
+            {
+                try { request = request.WithBotInfoConfidence(botInfoConfidence.Select(BotInfoConfidenceValueConverter.FromString).ToList()); }
+                catch { throw new ApiException("Invalid bot_info_confidence filter", HttpStatusCode.BadRequest, "{\"error\":{\"code\":\"request_cannot_be_parsed\",\"message\":\"invalid bot info confidence\"}}"); }
+            }
+            if (botInfoProvider is { Count: > 0 }) request = request.WithBotInfoProvider(botInfoProvider);
+            if (botInfoName is { Count: > 0 }) request = request.WithBotInfoName(botInfoName);
             if (sdkVersion != null) request = request.WithSdkVersion(sdkVersion);
             if (sdkPlatform != null)
             {

--- a/projects/dotnet-sdk/dotnet-sdk.csproj
+++ b/projects/dotnet-sdk/dotnet-sdk.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fingerprint.ServerSdk" Version="8.3.0-test.0" />
+    <PackageReference Include="Fingerprint.ServerSdk" Version="8.3.0-test.1" />
     <PackageReference Include="FingerprintPro.ServerSdk" Version="7.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/projects/dotnet-sdk/dotnet-sdk.csproj
+++ b/projects/dotnet-sdk/dotnet-sdk.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fingerprint.ServerSdk" Version="8.1.0" />
+    <PackageReference Include="Fingerprint.ServerSdk" Version="8.3.0-test.0" />
     <PackageReference Include="FingerprintPro.ServerSdk" Version="7.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/projects/go-sdk/go.mod
+++ b/projects/go-sdk/go.mod
@@ -4,4 +4,4 @@ go 1.23.0
 
 require github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.10.0
 
-require github.com/fingerprintjs/go-sdk/v8 v8.1.0
+require github.com/fingerprintjs/go-sdk/v8 v8.3.0-test.0

--- a/projects/go-sdk/go.sum
+++ b/projects/go-sdk/go.sum
@@ -2,3 +2,5 @@ github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.10.0 h1:1BzzOkZ
 github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.10.0/go.mod h1:MY0RfGfaWe6G4tyU8jEy/X+wbi0LIP0TSwDd4qudN9M=
 github.com/fingerprintjs/go-sdk/v8 v8.1.0 h1:4rjCO6RtMZ7YIX7zIGgp/cAfltzwGNY50LrY/d8R2Oo=
 github.com/fingerprintjs/go-sdk/v8 v8.1.0/go.mod h1:keVuTTvDofQYjzm6t+YXPZ9twIIk4UzpXOoXhJhjySc=
+github.com/fingerprintjs/go-sdk/v8 v8.3.0-test.0 h1:pd34sASE42cNIWllegK8zb2fc8DLBYfCJxn6kvrfCYI=
+github.com/fingerprintjs/go-sdk/v8 v8.3.0-test.0/go.mod h1:keVuTTvDofQYjzm6t+YXPZ9twIIk4UzpXOoXhJhjySc=

--- a/projects/go-sdk/handlers/v4/searchEvents.go
+++ b/projects/go-sdk/handlers/v4/searchEvents.go
@@ -2,9 +2,11 @@ package handlersv4
 
 import (
 	"encoding/json"
-	"go-sdk/fingerprintv4"
 	"net/http"
 	"strconv"
+	"time"
+
+	"go-sdk/fingerprintv4"
 
 	fingerprint "github.com/fingerprintjs/go-sdk/v8"
 )
@@ -19,7 +21,9 @@ func SearchEvents(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
 	var start *int64
+	var startDateTime *time.Time
 	var end *int64
+	var endDateTime *time.Time
 	var limit int32 = 10
 	var reverse *bool
 	var suspect *bool
@@ -44,10 +48,15 @@ func SearchEvents(w http.ResponseWriter, r *http.Request) {
 	var sdkPlatform *string
 	var environment []string
 	var proximityId *string
+	var botInfo *string
+	var botInfoCategory []fingerprint.BotInfoCategory
+	var botInfoIdentity []fingerprint.BotInfoIdentity
+	var botInfoConfidence []fingerprint.BotInfoConfidence
+	var botInfoProvider []string
+	var botInfoName []string
 
 	if query.Has("limit") {
-		limitInt64, _ :=
-			strconv.ParseInt(query.Get("limit"), 10, 32)
+		limitInt64, _ := strconv.ParseInt(query.Get("limit"), 10, 32)
 		limit = int32(limitInt64)
 	}
 	if query.Has("start") {
@@ -55,9 +64,19 @@ func SearchEvents(w http.ResponseWriter, r *http.Request) {
 			start = &startInt64
 		}
 	}
+	if query.Has("start_date_time") {
+		if val, err := time.Parse(time.RFC3339, query.Get("start_date_time")); err == nil {
+			startDateTime = &val
+		}
+	}
 	if query.Has("end") {
 		if endInt64, err := strconv.ParseInt(query.Get("end"), 10, 64); err == nil {
 			end = &endInt64
+		}
+	}
+	if query.Has("end_date_time") {
+		if val, err := time.Parse(time.RFC3339, query.Get("end_date_time")); err == nil {
+			endDateTime = &val
 		}
 	}
 	if query.Has("reverse") {
@@ -171,6 +190,25 @@ func SearchEvents(w http.ResponseWriter, r *http.Request) {
 		val := query.Get("proximity_id")
 		proximityId = &val
 	}
+	if query.Has("bot_info") {
+		val := query.Get("bot_info")
+		botInfo = &val
+	}
+	if query.Has("bot_info_category") {
+		botInfoCategory = convertStrSlice[fingerprint.BotInfoCategory](query["bot_info_category"])
+	}
+	if query.Has("bot_info_identity") {
+		botInfoIdentity = convertStrSlice[fingerprint.BotInfoIdentity](query["bot_info_identity"])
+	}
+	if query.Has("bot_info_confidence") {
+		botInfoConfidence = convertStrSlice[fingerprint.BotInfoConfidence](query["bot_info_confidence"])
+	}
+	if query.Has("bot_info_provider") {
+		botInfoProvider = query["bot_info_provider"]
+	}
+	if query.Has("bot_info_name") {
+		botInfoName = query["bot_info_name"]
+	}
 
 	paginationKey := query.Get("pagination_key")
 	visitorId := query.Get("visitor_id")
@@ -194,8 +232,14 @@ func SearchEvents(w http.ResponseWriter, r *http.Request) {
 	if start != nil {
 		searchEventsReq = searchEventsReq.Start(*start)
 	}
+	if startDateTime != nil {
+		searchEventsReq = searchEventsReq.StartDateTime(*startDateTime)
+	}
 	if end != nil {
 		searchEventsReq = searchEventsReq.End(*end)
+	}
+	if endDateTime != nil {
+		searchEventsReq = searchEventsReq.EndDateTime(*endDateTime)
 	}
 	if reverse != nil {
 		searchEventsReq = searchEventsReq.Reverse(*reverse)
@@ -275,6 +319,25 @@ func SearchEvents(w http.ResponseWriter, r *http.Request) {
 	if vpnConfidence != "" {
 		searchEventsReq = searchEventsReq.VPNConfidence(fingerprint.SearchEventsVPNConfidence(vpnConfidence))
 	}
+	if botInfo != nil {
+		searchEventsReq = searchEventsReq.BotInfo(fingerprint.SearchEventsBotInfo(*botInfo))
+	}
+	if len(botInfoCategory) > 0 {
+		searchEventsReq = searchEventsReq.BotInfoCategory(botInfoCategory)
+	}
+	if len(botInfoIdentity) > 0 {
+		searchEventsReq = searchEventsReq.BotInfoIdentity(botInfoIdentity)
+	}
+	if len(botInfoConfidence) > 0 {
+		searchEventsReq = searchEventsReq.BotInfoConfidence(botInfoConfidence)
+	}
+	if len(botInfoProvider) > 0 {
+		searchEventsReq = searchEventsReq.BotInfoProvider(botInfoProvider)
+	}
+	if len(botInfoName) > 0 {
+		searchEventsReq = searchEventsReq.BotInfoName(botInfoName)
+	}
+
 	queryParams := searchEventsQueryParams{
 		ApiKey:  query.Get("api_key"),
 		Region:  query.Get("region"),
@@ -287,4 +350,12 @@ func SearchEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 	json.NewEncoder(w).Encode(response)
+}
+
+func convertStrSlice[To ~string, From ~string](input []From) []To {
+	result := make([]To, len(input))
+	for i, v := range input {
+		result[i] = To(v)
+	}
+	return result
 }

--- a/projects/java-sdk/build.gradle.kts
+++ b/projects/java-sdk/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	implementation("com.github.fingerprintjs:fingerprint-pro-server-api-java-sdk:v7.12.0")
-	implementation("com.github.fingerprintjs:java-sdk:v8.1.0")
+	implementation("com.github.fingerprintjs:java-sdk:v8.3.0-rc.1")
 }
 
 tasks.withType<Test> {

--- a/projects/java-sdk/src/main/java/com/example/java_sdk/v4/EventController.java
+++ b/projects/java-sdk/src/main/java/com/example/java_sdk/v4/EventController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -69,13 +69,20 @@ public class EventController {
             @RequestParam(required = false) List<String> environment,
             @RequestParam(required = false) String proximity_id,
             @RequestParam(required = false) Long total_hits,
-            @RequestParam(required = false) Boolean tor_node
+            @RequestParam(required = false) Boolean tor_node,
+            @RequestParam(required = false) OffsetDateTime start_date_time,
+            @RequestParam(required = false) OffsetDateTime end_date_time,
+            @RequestParam(required = false) String bot_info,
+            @RequestParam(required = false) List<String> bot_info_category,
+            @RequestParam(required = false) List<String> bot_info_identity,
+            @RequestParam(required = false) List<String> bot_info_confidence,
+            @RequestParam(required = false) List<String> bot_info_provider,
+            @RequestParam(required = false) List<String> bot_info_name
     ) {
         ApiClient client = Configuration.getDefaultApiClient(api_key, Utils.getRegion(region));
         FingerprintApi api = new FingerprintApi(client);
         try {
-            final ApiResponse<EventSearch> apiResponse =
-                    api.searchEventsWithHttpInfo(new FingerprintApi.SearchEventsOptionalParams()
+            final FingerprintApi.SearchEventsOptionalParams params = new FingerprintApi.SearchEventsOptionalParams()
                             .setLimit(limit)
                             .setPaginationKey(pagination_key)
                             .setVisitorId(visitor_id)
@@ -115,7 +122,21 @@ public class EventController {
                             .setProximityId(proximity_id)
                             .setTotalHits(total_hits)
                             .setTorNode(tor_node)
-                    );
+                            .setBotInfo(bot_info != null ? SearchEventsBotInfo.fromValue(bot_info) : null)
+                            .setBotInfoCategory(bot_info_category != null ? bot_info_category.stream().map(BotInfoCategory::fromValue).toList() : null)
+                            .setBotInfoIdentity(bot_info_identity != null ? bot_info_identity.stream().map(BotInfoIdentity::fromValue).toList() : null)
+                            .setBotInfoConfidence(bot_info_confidence != null ? bot_info_confidence.stream().map(BotInfoConfidence::fromValue).toList() : null)
+                            .setBotInfoProvider(bot_info_provider)
+                            .setBotInfoName(bot_info_name);
+
+            if (start_date_time != null) {
+                params.setStartDateTime(start_date_time);
+            }
+            if (end_date_time != null) {
+                params.setEndDateTime(end_date_time);
+            }
+
+            final ApiResponse<EventSearch> apiResponse = api.searchEventsWithHttpInfo(params);
             final EventSearch events = apiResponse.getData();
             final int code = apiResponse.getStatusCode();
             final MusicianResponse response = new MusicianResponse(code, events, events);
@@ -131,13 +152,12 @@ public class EventController {
             @RequestParam(required = false, value = "") String api_key,
             @RequestParam(required = false, value = "") String region,
             @RequestParam(required = false, value = "") String event_id,
-            @RequestParam(required = false, value = "") String ruleset_id
-    ) {
+            @RequestParam(required = false, value = "") String ruleset_id) {
         ApiClient client = Configuration.getDefaultApiClient(api_key, Utils.getRegion(region));
         FingerprintApi api = new FingerprintApi(client);
         try {
-            final ApiResponse<Event> apiResponse = api.getEventWithHttpInfo(event_id, new FingerprintApi
-                    .GetEventOptionalParams().setRulesetId(ruleset_id));
+            final ApiResponse<Event> apiResponse = api.getEventWithHttpInfo(event_id,
+                    new FingerprintApi.GetEventOptionalParams().setRulesetId(ruleset_id));
             final Event event = apiResponse.getData();
             final int code = apiResponse.getStatusCode();
             final MusicianResponse response = new MusicianResponse(code, event, event);
@@ -155,8 +175,7 @@ public class EventController {
             @RequestParam(required = false, value = "") String event_id,
             @RequestParam(required = false) String linked_id,
             @RequestParam(required = false) String tags,
-            @RequestParam(required = false) Boolean suspect
-    ) {
+            @RequestParam(required = false) Boolean suspect) {
         ApiClient client = Configuration.getDefaultApiClient(api_key, Utils.getRegion(region));
         FingerprintApi api = new FingerprintApi(client);
         try {
@@ -165,16 +184,18 @@ public class EventController {
             eventsUpdateRequest.setSuspect(suspect);
             if (tags != null) {
                 try {
-                    Map<String, Object> parsedTag = objectMapper.readValue(tags, new TypeReference<Map<String, Object>>() {
-                    });
+                    Map<String, Object> parsedTag = objectMapper.readValue(tags,
+                            new TypeReference<Map<String, Object>>() {});
                     eventsUpdateRequest.setTags(parsedTag);
                 } catch (JsonProcessingException e) {
                 }
             }
 
-            final ApiResponse<Void> apiResponse = api.updateEventWithHttpInfo(event_id, eventsUpdateRequest);
+            final ApiResponse<Void> apiResponse =
+                    api.updateEventWithHttpInfo(event_id, eventsUpdateRequest);
             final int code = apiResponse.getStatusCode();
-            final MusicianResponse response = new MusicianResponse(code, apiResponse.getData(), apiResponse.getData());
+            final MusicianResponse response =
+                    new MusicianResponse(code, apiResponse.getData(), apiResponse.getData());
             return ResponseEntity.ok(response);
         } catch (ApiException e) {
             final MusicianResponse response = new MusicianResponse(e);

--- a/projects/node-sdk/package.json
+++ b/projects/node-sdk/package.json
@@ -6,7 +6,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@fingerprint/node-sdk": "^7.1.0",
+    "@fingerprint/node-sdk": "7.3.0-test.0",
     "@fingerprintjs/fingerprintjs-pro-server-api": "6.11.0",
     "express": "^5.0.1",
     "ts-node": "^10.9.2",

--- a/projects/node-sdk/src/handlers/v4/searchEvents.ts
+++ b/projects/node-sdk/src/handlers/v4/searchEvents.ts
@@ -4,11 +4,11 @@ import { Handler, MusicianResponse } from '../../types'
 import { getV4Region, parseBooleanFromString, parseNumberFromString, unwrapV4Error } from '../../utils'
 
 type V4SearchEventsFilter = NonNullable<SearchEventsFilter>
-type QueryParams = Omit<{ [K in keyof V4SearchEventsFilter]?: string }, 'environment'> & {
+type QueryParams = {
+  [K in keyof V4SearchEventsFilter]?: NonNullable<V4SearchEventsFilter[K]> extends readonly unknown[] ? string[] : string
+} & {
   api_key?: string
   region?: string
-  // Parameters that can have multiple values
-  environment?: string | string[]
 }
 
 export const searchEvents: Handler<QueryParams> = async (req, res) => {

--- a/projects/node-sdk/src/handlers/v4/searchEvents.ts
+++ b/projects/node-sdk/src/handlers/v4/searchEvents.ts
@@ -7,7 +7,7 @@ type V4SearchEventsFilter = NonNullable<SearchEventsFilter>
 type QueryParams = Omit<{ [K in keyof V4SearchEventsFilter]?: string }, 'environment'> & {
   api_key?: string
   region?: string
-  // Only environment can be multiple values
+  // Parameters that can have multiple values
   environment?: string | string[]
 }
 
@@ -21,6 +21,12 @@ export const searchEvents: Handler<QueryParams> = async (req, res) => {
     pagination_key,
     visitor_id,
     bot,
+    bot_info,
+    bot_info_category,
+    bot_info_identity,
+    bot_info_confidence,
+    bot_info_provider,
+    bot_info_name,
     ip_address,
     linked_id,
     start,
@@ -77,6 +83,30 @@ export const searchEvents: Handler<QueryParams> = async (req, res) => {
     if (bot !== undefined) {
       filter.bot = bot as NonNullable<V4SearchEventsFilter['bot']>
     }
+    if (bot_info !== undefined) {
+      filter.bot_info = bot_info as NonNullable<V4SearchEventsFilter['bot_info']>
+    }
+    if (bot_info_category !== undefined) {
+      filter.bot_info_category = (
+        Array.isArray(bot_info_category) ? bot_info_category : [bot_info_category]
+      ) as NonNullable<V4SearchEventsFilter['bot_info_category']>
+    }
+    if (bot_info_identity !== undefined) {
+      filter.bot_info_identity = (
+        Array.isArray(bot_info_identity) ? bot_info_identity : [bot_info_identity]
+      ) as NonNullable<V4SearchEventsFilter['bot_info_identity']>
+    }
+    if (bot_info_confidence !== undefined) {
+      filter.bot_info_confidence = (
+        Array.isArray(bot_info_confidence) ? bot_info_confidence : [bot_info_confidence]
+      ) as NonNullable<V4SearchEventsFilter['bot_info_confidence']>
+    }
+    if (bot_info_provider !== undefined) {
+      filter.bot_info_provider = Array.isArray(bot_info_provider) ? bot_info_provider : [bot_info_provider]
+    }
+    if (bot_info_name !== undefined) {
+      filter.bot_info_name = Array.isArray(bot_info_name) ? bot_info_name : [bot_info_name]
+    }
     if (ip_address !== undefined) {
       filter.ip_address = ip_address
     }
@@ -84,10 +114,12 @@ export const searchEvents: Handler<QueryParams> = async (req, res) => {
       filter.linked_id = linked_id
     }
     if (start !== undefined) {
-      filter.start = parseNumberFromString(start, 'start')
+      const numStart = Number(start)
+      filter.start = Number.isFinite(numStart) ? numStart : start
     }
     if (end !== undefined) {
-      filter.end = parseNumberFromString(end, 'end')
+      const numEnd = Number(end)
+      filter.end = Number.isFinite(numEnd) ? numEnd : end
     }
     if (reverse !== undefined) {
       filter.reverse = parseBooleanFromString(reverse, 'reverse')

--- a/projects/php-sdk/composer.json
+++ b/projects/php-sdk/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "fingerprint/fingerprint-pro-server-api-sdk": "6.11.0",
-        "fingerprint/server-sdk": "7.2.0-beta.1",
+        "fingerprint/server-sdk": "7.2.0-beta.2",
         "slim/slim": "^4.15.1"
     },
     "autoload": {

--- a/projects/php-sdk/composer.json
+++ b/projects/php-sdk/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "fingerprint/fingerprint-pro-server-api-sdk": "6.11.0",
-        "fingerprint/server-sdk": "7.0.0",
+        "fingerprint/server-sdk": "7.2.0-beta.1",
         "slim/slim": "^4.15.1"
     },
     "autoload": {

--- a/projects/php-sdk/composer.lock
+++ b/projects/php-sdk/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77c3a0d6a6ed32851147ad56da64675c",
+    "content-hash": "15725ec59a7242e4834bbe7bee31dcd3",
     "packages": [
         {
             "name": "fingerprint/fingerprint-pro-server-api-sdk",
@@ -78,16 +78,16 @@
         },
         {
             "name": "fingerprint/server-sdk",
-            "version": "7.2.0-beta.1",
+            "version": "7.2.0-beta.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fingerprintjs/php-sdk.git",
-                "reference": "76a749aa950ecacf43cc90065fc6fa087c538cad"
+                "reference": "58c3f1b9bb6224f215aa12cbb9b0643bcfacfaac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fingerprintjs/php-sdk/zipball/76a749aa950ecacf43cc90065fc6fa087c538cad",
-                "reference": "76a749aa950ecacf43cc90065fc6fa087c538cad",
+                "url": "https://api.github.com/repos/fingerprintjs/php-sdk/zipball/58c3f1b9bb6224f215aa12cbb9b0643bcfacfaac",
+                "reference": "58c3f1b9bb6224f215aa12cbb9b0643bcfacfaac",
                 "shasum": ""
             },
             "require": {
@@ -147,9 +147,9 @@
             ],
             "support": {
                 "issues": "https://github.com/fingerprintjs/php-sdk/issues",
-                "source": "https://github.com/fingerprintjs/php-sdk/tree/v7.2.0-beta.1"
+                "source": "https://github.com/fingerprintjs/php-sdk/tree/v7.2.0-beta.2"
             },
-            "time": "2026-05-20T15:45:11+00:00"
+            "time": "2026-05-21T09:55:52+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/projects/php-sdk/composer.lock
+++ b/projects/php-sdk/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "188e38bb18c08be714f0652e929469a4",
+    "content-hash": "77c3a0d6a6ed32851147ad56da64675c",
     "packages": [
         {
             "name": "fingerprint/fingerprint-pro-server-api-sdk",
@@ -78,16 +78,16 @@
         },
         {
             "name": "fingerprint/server-sdk",
-            "version": "7.0.0",
+            "version": "7.2.0-beta.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fingerprintjs/php-sdk.git",
-                "reference": "a6e38824c092beeb27523728c28422c2eda96c42"
+                "reference": "76a749aa950ecacf43cc90065fc6fa087c538cad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fingerprintjs/php-sdk/zipball/a6e38824c092beeb27523728c28422c2eda96c42",
-                "reference": "a6e38824c092beeb27523728c28422c2eda96c42",
+                "url": "https://api.github.com/repos/fingerprintjs/php-sdk/zipball/76a749aa950ecacf43cc90065fc6fa087c538cad",
+                "reference": "76a749aa950ecacf43cc90065fc6fa087c538cad",
                 "shasum": ""
             },
             "require": {
@@ -147,22 +147,22 @@
             ],
             "support": {
                 "issues": "https://github.com/fingerprintjs/php-sdk/issues",
-                "source": "https://github.com/fingerprintjs/php-sdk/tree/v7.0.0"
+                "source": "https://github.com/fingerprintjs/php-sdk/tree/v7.2.0-beta.1"
             },
-            "time": "2026-04-16T11:56:27+00:00"
+            "time": "2026-05-20T15:45:11+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "aed36fd5fb4844f284252a999d9abf35d3a9a1ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aed36fd5fb4844f284252a999d9abf35d3a9a1ae",
+                "reference": "aed36fd5fb4844f284252a999d9abf35d3a9a1ae",
                 "shasum": ""
             },
             "require": {
@@ -180,8 +180,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.3.2",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -259,7 +260,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.2"
             },
             "funding": [
                 {
@@ -275,20 +276,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-05-20T11:58:52+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "d2d8dfae4757f384d630fdffc2d8d6618d8f4c5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/d2d8dfae4757f384d630fdffc2d8d6618d8f4c5e",
+                "reference": "d2d8dfae4757f384d630fdffc2d8d6618d8f4c5e",
                 "shasum": ""
             },
             "require": {
@@ -296,7 +297,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -342,7 +343,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.3.1"
             },
             "funding": [
                 {
@@ -358,20 +359,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-05-19T18:30:48+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
                 "shasum": ""
             },
             "require": {
@@ -386,9 +387,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -459,7 +460,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
             },
             "funding": [
                 {
@@ -475,7 +476,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-05-20T09:27:36+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -1065,16 +1066,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -1087,7 +1088,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1112,7 +1113,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1124,17 +1125,23 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "fingerprint/server-sdk": 10
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/projects/php-sdk/src/V4/Controllers/EventsController.php
+++ b/projects/php-sdk/src/V4/Controllers/EventsController.php
@@ -2,8 +2,12 @@
 
 namespace PHP_SDK\V4\Controllers;
 
+use Fingerprint\ServerSdk\Model\BotInfoCategory;
+use Fingerprint\ServerSdk\Model\BotInfoConfidence;
+use Fingerprint\ServerSdk\Model\BotInfoIdentity;
 use Fingerprint\ServerSdk\Model\EventUpdate;
 use Fingerprint\ServerSdk\Model\SearchEventsBot;
+use Fingerprint\ServerSdk\Model\SearchEventsBotInfo;
 use Fingerprint\ServerSdk\Model\SearchEventsIncrementalIdentificationStatus;
 use Fingerprint\ServerSdk\Model\SearchEventsSdkPlatform;
 use Fingerprint\ServerSdk\Model\SearchEventsVpnConfidence;
@@ -34,6 +38,7 @@ class EventsController
             $visitorId = $queryParams['visitor_id'] ?? null;
             $highRecallId = $queryParams['high_recall_id'] ?? null;
             $bot = isset($queryParams['bot']) ? SearchEventsBot::from($queryParams['bot']) : null;
+            $botInfo = isset($queryParams['bot_info']) ? SearchEventsBotInfo::from($queryParams['bot_info']) : null;
             $ipAddress = $queryParams['ip_address'] ?? null;
             $asn = $queryParams['asn'] ?? null;
             $linkedId = $queryParams['linked_id'] ?? null;
@@ -41,8 +46,8 @@ class EventsController
             $bundleId = $queryParams['bundle_id'] ?? null;
             $packageName = $queryParams['package_name'] ?? null;
             $origin = $queryParams['origin'] ?? null;
-            $start = isset($queryParams['start']) ? (int) $queryParams['start'] : null;
-            $end = isset($queryParams['end']) ? (int) $queryParams['end'] : null;
+            $start = isset($queryParams['start']) ? (is_numeric($queryParams['start']) ? (int) $queryParams['start'] : new \DateTime($queryParams['start'])) : null;
+            $end = isset($queryParams['end']) ? (is_numeric($queryParams['end']) ? (int) $queryParams['end'] : new \DateTime($queryParams['end'])) : null;
             $reverse = isset($queryParams['reverse']) ? filter_var($queryParams['reverse'], FILTER_VALIDATE_BOOLEAN) : null;
             $suspect = isset($queryParams['suspect']) ? filter_var($queryParams['suspect'], FILTER_VALIDATE_BOOLEAN) : null;
             $vpn = isset($queryParams['vpn']) ? filter_var($queryParams['vpn'], FILTER_VALIDATE_BOOLEAN) : null;
@@ -71,23 +76,50 @@ class EventsController
             $incrementalIdentificationStatus = isset($queryParams['incremental_identification_status']) ? SearchEventsIncrementalIdentificationStatus::from($queryParams['incremental_identification_status']) : null;
             $simulator = isset($queryParams['simulator']) ? filter_var($queryParams['simulator'], FILTER_VALIDATE_BOOLEAN) : null;
 
-            // Parse environment from raw query string since repeated keys (environment=a&environment=b)
+            // Parse array parameters from raw query string since repeated keys (key=a&key=b)
             // are collapsed to the last value by PHP's parse_str / getQueryParams().
             $environment = null;
+            $botInfoCategory = null;
+            $botInfoIdentity = null;
+            $botInfoConfidence = null;
+            $botInfoProvider = null;
+            $botInfoName = null;
             $rawQuery = $request->getUri()->getQuery();
             if ($rawQuery) {
-                $environmentValues = [];
+                $arrayParams = [
+                    'environment' => [],
+                    'bot_info_category' => [],
+                    'bot_info_identity' => [],
+                    'bot_info_confidence' => [],
+                    'bot_info_provider' => [],
+                    'bot_info_name' => [],
+                ];
                 foreach (explode('&', $rawQuery) as $pair) {
                     $parts = explode('=', $pair, 2);
-                    if ($parts[0] === 'environment' && isset($parts[1])) {
+                    if (isset($parts[1]) && array_key_exists($parts[0], $arrayParams)) {
                         $value = trim(urldecode($parts[1]));
                         if ($value !== '') {
-                            $environmentValues[] = $value;
+                            $arrayParams[$parts[0]][] = $value;
                         }
                     }
                 }
-                if (!empty($environmentValues)) {
-                    $environment = $environmentValues;
+                if (!empty($arrayParams['environment'])) {
+                    $environment = $arrayParams['environment'];
+                }
+                if (!empty($arrayParams['bot_info_category'])) {
+                    $botInfoCategory = array_map(fn($v) => BotInfoCategory::from($v), $arrayParams['bot_info_category']);
+                }
+                if (!empty($arrayParams['bot_info_identity'])) {
+                    $botInfoIdentity = array_map(fn($v) => BotInfoIdentity::from($v), $arrayParams['bot_info_identity']);
+                }
+                if (!empty($arrayParams['bot_info_confidence'])) {
+                    $botInfoConfidence = array_map(fn($v) => BotInfoConfidence::from($v), $arrayParams['bot_info_confidence']);
+                }
+                if (!empty($arrayParams['bot_info_provider'])) {
+                    $botInfoProvider = $arrayParams['bot_info_provider'];
+                }
+                if (!empty($arrayParams['bot_info_name'])) {
+                    $botInfoName = $arrayParams['bot_info_name'];
                 }
             }
 
@@ -99,6 +131,12 @@ class EventsController
                 visitor_id: $visitorId,
                 high_recall_id: $highRecallId,
                 bot: $bot,
+                bot_info: $botInfo,
+                bot_info_category: $botInfoCategory,
+                bot_info_identity: $botInfoIdentity,
+                bot_info_confidence: $botInfoConfidence,
+                bot_info_provider: $botInfoProvider,
+                bot_info_name: $botInfoName,
                 ip_address: $ipAddress,
                 asn: $asn,
                 linked_id: $linkedId,

--- a/projects/python-sdk/handlers/v4/search_events.py
+++ b/projects/python-sdk/handlers/v4/search_events.py
@@ -51,6 +51,12 @@ def search_events():
         "proximity_id": request.args.get('proximity_id'),
         "total_hits": request.args.get('total_hits', type=int),
         "tor_node": _parse_bool(request.args.get('tor_node')),
+        "bot_info": request.args.get('bot_info'),
+        "bot_info_category": request.args.getlist('bot_info_category'),
+        "bot_info_identity": request.args.getlist('bot_info_identity'),
+        "bot_info_confidence": request.args.getlist('bot_info_confidence'),
+        "bot_info_provider": request.args.getlist('bot_info_provider'),
+        "bot_info_name": request.args.getlist('bot_info_name'),
     }
 
     filtered_additional_params = {key: value for key, value in additional_params.items() if value is not None}

--- a/projects/python-sdk/requirements.txt
+++ b/projects/python-sdk/requirements.txt
@@ -1,4 +1,4 @@
 fingerprint_pro_server_api_sdk==8.13.0
-fingerprint-server-sdk==9.1.0
+fingerprint-server-sdk==9.3.0-rc.0
 flask>=3.1
 pydantic>=2

--- a/scripts/setup-sdk.sh
+++ b/scripts/setup-sdk.sh
@@ -91,7 +91,7 @@ case $LANGUAGE in
         pip install "fingerprint-server-sdk==$SDK_VERSION"
         ;;
     "php")
-        composer require fingerprint/fingerprint-pro-server-api-sdk:$SDK_VERSION --update-with-dependencies
+        composer require fingerprint/server-sdk:$SDK_VERSION --update-with-dependencies
         ;;
     *)
         echo "Unknown language: $LANGUAGE"


### PR DESCRIPTION
- Update searchEvents test to add support for the following query parameters:
  - `bot_info`
  - `bot_info_category`
  - `bot_info_identity`
  - `bot_info_confidence`
  - `bot_info_provider`
  - `bot_info_name`
- Add coverage for `start_date_time` and `end_date_time`
- Add helper function to determine if the SDK under test supports `start_date_time`/`end_date_time` based on the musician port used.
- Update the test app code for each SDK to add the above query parameters to the search events API.