### PR TITLE
INTER-1922: Add registry version availability check

### DIFF
--- a/.github/workflows/server-sdk-e2e-tests.yml
+++ b/.github/workflows/server-sdk-e2e-tests.yml
@@ -106,6 +106,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Wait for Node SDK availability on registry
+        if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
+        working-directory: ./projects/node-sdk
+        run: ../../scripts/wait-for-sdk-availability.sh node ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+
       - name: Set up Node SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/node-sdk
@@ -262,6 +267,11 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
+      - name: Wait for Java SDK availability on registry
+        if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
+        working-directory: ./projects/java-sdk
+        run: ../../scripts/wait-for-sdk-availability.sh java ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+
       - name: Set up Java SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/java-sdk
@@ -411,6 +421,11 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore ./projects/dotnet-sdk
+
+      - name: Wait for .NET SDK availability on registry
+        if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
+        working-directory: ./projects/dotnet-sdk
+        run: ../../scripts/wait-for-sdk-availability.sh dotnet ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
 
       - name: Set up .NET SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
@@ -569,6 +584,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-mod-
 
+      - name: Wait for Go SDK availability on registry
+        if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
+        working-directory: ./projects/go-sdk
+        run: ../../scripts/wait-for-sdk-availability.sh go ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+
       - name: Set up Go SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/go-sdk
@@ -726,6 +746,11 @@ jobs:
         run: |
           pip install -r requirements.txt
 
+      - name: Wait for Python SDK availability on registry
+        if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
+        working-directory: ./projects/python-sdk
+        run: ../../scripts/wait-for-sdk-availability.sh python ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+
       - name: Set up Python SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/python-sdk
@@ -881,6 +906,11 @@ jobs:
         working-directory: ./projects/php-sdk
         run: |
           composer install --no-interaction
+
+      - name: Wait for PHP SDK availability on registry
+        if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
+        working-directory: ./projects/php-sdk
+        run: ../../scripts/wait-for-sdk-availability.sh php ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
 
       - name: Set up PHP SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}

--- a/scripts/wait-for-sdk-availability.sh
+++ b/scripts/wait-for-sdk-availability.sh
@@ -43,7 +43,7 @@ case $LANGUAGE in
         ;;
     "php")
         VERSION="$strip_v"
-        CHECK_URL="https://repo.packagist.org/p2/fingerprint/fingerprint-pro-server-api-sdk.json"
+        CHECK_URL="https://repo.packagist.org/p2/fingerprint/server-sdk.json"
         ;;
     *)
         echo "Unknown language: $LANGUAGE"
@@ -55,7 +55,7 @@ check_version_available() {
     # PHP requires parsing the JSON response to find the specific version
     if [[ "$LANGUAGE" == "php" ]]; then
         curl -sf "$CHECK_URL" | \
-            jq -e ".packages[\"fingerprint/fingerprint-pro-server-api-sdk\"][] | select(.version == \"$VERSION\")" > /dev/null
+            jq -e ".packages[\"fingerprint/server-sdk\"][] | select(.version == \"$VERSION\")" > /dev/null
     else
         curl "${CURL_OPTS[@]}" "$CHECK_URL"
     fi

--- a/scripts/wait-for-sdk-availability.sh
+++ b/scripts/wait-for-sdk-availability.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -e
+
+LANGUAGE=$1
+SDK_VERSION=$2
+
+MAX_ATTEMPTS=30
+INITIAL_DELAY=10
+MAX_DELAY=60
+CURL_OPTS=(-sf -o /dev/null)
+
+if [[ -z "$LANGUAGE" || -z "$SDK_VERSION" ]]; then
+    echo "Usage: wait-for-sdk-availability.sh <language> <version>"
+    echo "Languages: node, java, dotnet, go, python, php"
+    exit 1
+fi
+
+strip_v="${SDK_VERSION#v}"
+with_v="v$strip_v"
+
+# Normalize version and build registry check URL per language
+case $LANGUAGE in
+    "node")
+        VERSION="$strip_v"
+        CHECK_URL="https://registry.npmjs.org/@fingerprint%2Fnode-sdk/$VERSION"
+        ;;
+    "java")
+        VERSION="$with_v"
+        CHECK_URL="https://jitpack.io/com/github/fingerprintjs/java-sdk/$VERSION/java-sdk-$VERSION.pom"
+        ;;
+    "dotnet")
+        VERSION=$(echo "$strip_v" | tr '[:upper:]' '[:lower:]')
+        CHECK_URL="https://api.nuget.org/v3-flatcontainer/fingerprint.serversdk/$VERSION/fingerprint.serversdk.nuspec"
+        ;;
+    "go")
+        VERSION="$with_v"
+        MAJOR_VERSION=$(echo "$VERSION" | cut -d'.' -f1)
+        CHECK_URL="https://proxy.golang.org/github.com/fingerprintjs/go-sdk/$MAJOR_VERSION/@v/$VERSION.info"
+        ;;
+    "python")
+        VERSION="$strip_v"
+        CHECK_URL="https://pypi.org/pypi/fingerprint-server-sdk/$VERSION/json"
+        ;;
+    "php")
+        VERSION="$strip_v"
+        CHECK_URL="https://repo.packagist.org/p2/fingerprint/fingerprint-pro-server-api-sdk.json"
+        ;;
+    *)
+        echo "Unknown language: $LANGUAGE"
+        exit 1
+        ;;
+esac
+
+check_version_available() {
+    # PHP requires parsing the JSON response to find the specific version
+    if [[ "$LANGUAGE" == "php" ]]; then
+        curl -sf "$CHECK_URL" | \
+            jq -e ".packages[\"fingerprint/fingerprint-pro-server-api-sdk\"][] | select(.version == \"$VERSION\")" > /dev/null
+    else
+        curl "${CURL_OPTS[@]}" "$CHECK_URL"
+    fi
+}
+
+echo "Waiting for $LANGUAGE SDK version $VERSION to become available on the package registry..."
+
+delay=$INITIAL_DELAY
+for attempt in $(seq 1 $MAX_ATTEMPTS); do
+    if check_version_available; then
+        echo "Version $VERSION is available on the registry (attempt $attempt)"
+        exit 0
+    fi
+
+    if [[ $attempt -eq $MAX_ATTEMPTS ]]; then
+        echo "ERROR: Version $VERSION not available after $MAX_ATTEMPTS attempts. Giving up."
+        exit 1
+    fi
+
+    echo "Attempt $attempt/$MAX_ATTEMPTS: Version $VERSION not yet available. Retrying in ${delay}s..."
+    sleep "$delay"
+
+    delay=$((delay * 2))
+    if [[ $delay -gt $MAX_DELAY ]]; then
+        delay=$MAX_DELAY
+    fi
+done


### PR DESCRIPTION
## Summary

- Add `scripts/wait-for-sdk-availability.sh` that polls package registries (10s -> 20s -> 40s -> 60s, max 30 attempts, max ~15min)
- Add "Wait for SDK availability" step before each SDK setup step in the e2e workflow, triggered on `repository_dispatch` and `workflow_dispatch` with a specific version (not `latest`)