### PR TITLE
chore: add Docker config to test against an unreleased SDK branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,77 @@
 start-all:
 	docker-compose up --build -d
+
+start-all-branch:
+	JAVA_SDK_BRANCH=$(JAVA_SDK_BRANCH) \
+	DOTNET_SDK_BRANCH=$(DOTNET_SDK_BRANCH) \
+	GO_SDK_BRANCH=$(GO_SDK_BRANCH) \
+	NODE_SDK_BRANCH=$(NODE_SDK_BRANCH) \
+	PYTHON_SDK_BRANCH=$(PYTHON_SDK_BRANCH) \
+	PHP_SDK_BRANCH=$(PHP_SDK_BRANCH) \
+	docker-compose -f docker-compose.yml -f docker-compose.branch.yml up --build -d
+
+start-all-same-branch:
+	JAVA_SDK_BRANCH=$(SDK_BRANCH) \
+	DOTNET_SDK_BRANCH=$(SDK_BRANCH) \
+	GO_SDK_BRANCH=$(SDK_BRANCH) \
+	NODE_SDK_BRANCH=$(SDK_BRANCH) \
+	PYTHON_SDK_BRANCH=$(SDK_BRANCH) \
+	PHP_SDK_BRANCH=$(SDK_BRANCH) \
+	docker-compose -f docker-compose.yml -f docker-compose.branch.yml up --build -d
+
 stop-all:
 	docker-compose down
 
 start-java:
 	docker-compose up java-sdk --build -d
 
+start-java-branch:
+	JAVA_SDK_BRANCH=$(JAVA_SDK_BRANCH) docker-compose -f docker-compose.yml -f docker-compose.branch.yml up java-sdk --build -d
+
+stop-java:
+	docker-compose kill java-sdk
+
 start-dotnet:
 	docker-compose up dotnet-sdk --build -d
 
-start-go:
-	docker-compose up go-sdk --build -d
-
-start-node:
-	docker-compose up node-sdk --build -d
-
-start-python:
-	docker-compose up python-sdk --build -d
-
-start-php:
-	docker-compose up php-sdk --build -d
-
-stop-php:
-	docker-compose kill php-sdk
-
-stop-python:
-	docker-compose kill python-sdk
-
-stop-node:
-	docker-compose kill node-sdk
-
-stop-go:
-	docker-compose kill go-sdk
+start-dotnet-branch:
+	DOTNET_SDK_BRANCH=$(DOTNET_SDK_BRANCH) docker-compose -f docker-compose.yml -f docker-compose.branch.yml up dotnet-sdk --build -d
 
 stop-dotnet:
 	docker-compose kill dotnet-sdk
 
-stop-java:
-	docker-compose kill java-sdk
+start-go:
+	docker-compose up go-sdk --build -d
+
+start-go-branch:
+	GO_SDK_BRANCH=$(GO_SDK_BRANCH) docker-compose -f docker-compose.yml -f docker-compose.branch.yml up go-sdk --build -d
+
+stop-go:
+	docker-compose kill go-sdk
+
+start-node:
+	docker-compose up node-sdk --build -d
+
+start-node-branch:
+	NODE_SDK_BRANCH=$(NODE_SDK_BRANCH) docker-compose -f docker-compose.yml -f docker-compose.branch.yml up node-sdk --build -d
+
+stop-node:
+	docker-compose kill node-sdk
+
+start-python:
+	docker-compose up python-sdk --build -d
+
+start-python-branch:
+	PYTHON_SDK_BRANCH=$(PYTHON_SDK_BRANCH) docker-compose -f docker-compose.yml -f docker-compose.branch.yml up python-sdk --build -d
+
+stop-python:
+	docker-compose kill python-sdk
+
+start-php:
+	docker-compose up php-sdk --build -d
+
+start-php-branch:
+	PHP_SDK_BRANCH=$(PHP_SDK_BRANCH) docker-compose -f docker-compose.yml -f docker-compose.branch.yml up php-sdk --build -d
+
+stop-php:
+	docker-compose kill php-sdk

--- a/README.md
+++ b/README.md
@@ -206,10 +206,9 @@ Suppose we’re adding `/getRelatedVisitors`:
 Each SDK project has a `Dockerfile.branch` file that supports building against a branch in the SDK GitHub repo.
 
 The Makefile has targets for using this `Dockerfile`. Use the `NAME_SDK_BRANCH` environment variable to specify
-the branch name, replacing `NAME` with one of the name of the SDK e.g., `DOTNET_SDK_VERSION`, `NODE_SDK_VERSION`, etc.
+the branch name, replacing `NAME` with an SDK name e.g., `DOTNET_SDK_VERSION`, `NODE_SDK_VERSION`, etc.
 
-If all the repos have the same branch, the Makefile's `start-all-same-branch` target can be used. This is helpful
-for running the tests against a schema sync PR in all the SDK repos:
+Use the `start-all-same-branch` target to run the tests against schema sync PRs in the SDK repos:
 
 ```
 $ make start-all-same-branch SDK_VERSION=feat/open-api-v3.3.1

--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ Suppose we’re adding `/getRelatedVisitors`:
 Each SDK project has a `Dockerfile.branch` file that supports building against a branch in the SDK GitHub repo.
 
 The Makefile has targets for using this `Dockerfile`. Use the `NAME_SDK_BRANCH` environment variable to specify
-the branch name, replacing `NAME` with an SDK name e.g., `DOTNET_SDK_VERSION`, `NODE_SDK_VERSION`, etc.
+the branch name, replacing `NAME` with an SDK name e.g., `DOTNET_SDK_BRANCH`, `NODE_SDK_BRANCH`, etc.
 
 Use the `start-all-same-branch` target to run the tests against schema sync PRs in the SDK repos:
 
 ```
-$ make start-all-same-branch SDK_VERSION=feat/open-api-v3.3.1
+$ make start-all-same-branch SDK_BRANCH=feat/open-api-v3.3.1
 ```
 
 ## Updating SDK versions

--- a/README.md
+++ b/README.md
@@ -201,6 +201,20 @@ Suppose we’re adding `/getRelatedVisitors`:
 - If a test mutates shared state or depends on prior artifacts, put it in a serial describe and add a short header comment explaining the dependency (future readers will thank you).
 - If you hit API limits, add conservative timeouts and retries only for the affected tests; avoid blanket retries that can hide real issues.
 
+### Running tests against an unreleased SDK branch
+
+Each SDK project has a `Dockerfile.branch` file that supports building against a branch in the SDK GitHub repo.
+
+The Makefile has targets for using this `Dockerfile`. Use the `NAME_SDK_BRANCH` environment variable to specify
+the branch name, replacing `NAME` with one of the name of the SDK e.g., `DOTNET_SDK_VERSION`, `NODE_SDK_VERSION`, etc.
+
+If all the repos have the same branch, the Makefile's `start-all-same-branch` target can be used. This is helpful
+for running the tests against a schema sync PR in all the SDK repos:
+
+```
+$ make start-all-same-branch SDK_VERSION=feat/open-api-v3.3.1
+```
+
 ## Updating SDK versions
 
 There are two supported ways to bump Server SDK versions: via the helper script (recommended) or manually per language.

--- a/docker-compose.branch.yml
+++ b/docker-compose.branch.yml
@@ -1,0 +1,33 @@
+# An override for the docker-compose configuration
+# that can be used to build against a branch of the SDKs
+services:
+  java-sdk:
+    build:
+      dockerfile: Dockerfile.branch
+      args:
+        SDK_BRANCH: ${JAVA_SDK_BRANCH:-main}
+  dotnet-sdk:
+    build:
+      dockerfile: Dockerfile.branch
+      args:
+        SDK_BRANCH: ${DOTNET_SDK_BRANCH:-main}
+  go-sdk:
+    build:
+      dockerfile: Dockerfile.branch
+      args:
+        SDK_BRANCH: ${GO_SDK_BRANCH:-main}
+  node-sdk:
+    build:
+      dockerfile: Dockerfile.branch
+      args:
+        SDK_BRANCH: ${NODE_SDK_BRANCH:-main}
+  php-sdk:
+    build:
+      dockerfile: Dockerfile.branch
+      args:
+        SDK_BRANCH: ${PHP_SDK_BRANCH:-main}
+  python-sdk:
+    build:
+      dockerfile: Dockerfile.branch
+      args:
+        SDK_BRANCH: ${PYTHON_SDK_BRANCH:-main}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   java-sdk:
     networks:

--- a/projects/dotnet-sdk/Dockerfile.branch
+++ b/projects/dotnet-sdk/Dockerfile.branch
@@ -1,0 +1,48 @@
+ARG SDK_BRANCH=main
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS sdk-builder
+
+ARG SDK_BRANCH
+
+WORKDIR /sdk
+
+RUN apt-get update && apt-get install -y git
+
+RUN git clone --branch ${SDK_BRANCH} --depth 1 https://github.com/fingerprintjs/dotnet-sdk.git .
+
+RUN SDK_VERSION=$(awk -F'"' '/"version"/{print $4; exit}' package.json)-local && \
+    echo "${SDK_VERSION}" > /sdk_version.txt && \
+    sed -i 's|<TargetFrameworks>.*</TargetFrameworks>|<TargetFramework>net9.0</TargetFramework>|' src/Fingerprint.ServerSdk/Fingerprint.ServerSdk.csproj && \
+    dotnet build "src/Fingerprint.ServerSdk/Fingerprint.ServerSdk.csproj" -c Release -p:Version=${SDK_VERSION} && \
+    dotnet pack "src/Fingerprint.ServerSdk/Fingerprint.ServerSdk.csproj" -c Release -p:Version=${SDK_VERSION} --no-build -o /packages
+
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+
+WORKDIR /App
+
+COPY --from=sdk-builder /packages /local-packages
+COPY --from=sdk-builder /sdk_version.txt /sdk_version.txt
+
+RUN dotnet nuget add source /local-packages --name local-packages
+
+COPY . .
+
+RUN SDK_VERSION=$(cat /sdk_version.txt) && \
+    sed -i "s|<PackageReference Include=\"Fingerprint\.ServerSdk\" Version=\"[^\"]*\"|<PackageReference Include=\"Fingerprint.ServerSdk\" Version=\"${SDK_VERSION}\"|g" dotnet-sdk.csproj
+
+RUN dotnet restore
+RUN dotnet publish -c Release -o out
+
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS run
+
+WORKDIR /App
+
+COPY --from=build /App/out .
+
+ENV HTTP_PORTS=5243
+
+EXPOSE 5243
+
+ENTRYPOINT ["dotnet", "dotnet-sdk.dll"]

--- a/projects/go-sdk/Dockerfile.branch
+++ b/projects/go-sdk/Dockerfile.branch
@@ -1,0 +1,23 @@
+ARG SDK_BRANCH=main
+
+FROM golang:1.23-alpine
+
+ARG SDK_BRANCH
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+
+COPY . .
+
+RUN git clone --branch ${SDK_BRANCH} --depth 1 https://github.com/fingerprintjs/go-sdk.git /sdk
+
+RUN go mod edit -replace github.com/fingerprintjs/go-sdk/v8=/sdk
+
+RUN go mod tidy
+
+RUN go build -o myapp .
+
+EXPOSE 8081
+
+CMD ["./myapp"]

--- a/projects/java-sdk/Dockerfile.branch
+++ b/projects/java-sdk/Dockerfile.branch
@@ -1,0 +1,52 @@
+ARG SDK_BRANCH=main
+
+FROM gradle:8.11.1-jdk17 AS sdk-builder
+
+ARG SDK_BRANCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+
+USER gradle
+
+WORKDIR /home/gradle/sdk
+
+RUN git clone --branch ${SDK_BRANCH} --depth 1 https://github.com/fingerprintjs/java-sdk.git .
+
+# JITPACK=true skips openApiGenerate, format, and downloadGoogleJavaFormat tasks,
+# building directly from committed sources as JitPack itself does.
+RUN JITPACK=true gradle :sdk:publishToMavenLocal --no-daemon -PjavaVersion=17 -Dmaven.repo.local=/home/gradle/m2
+
+RUN grep "^projectVersion" gradle.properties | awk -F'=' '{print $2}' | tr -d ' ' > /home/gradle/sdk_version.txt
+
+
+FROM gradle:8.11.1-jdk17 AS build
+
+USER gradle
+
+WORKDIR /home/gradle/app
+
+COPY --chown=gradle:gradle --from=sdk-builder /home/gradle/m2 /home/gradle/m2
+COPY --chown=gradle:gradle --from=sdk-builder /home/gradle/sdk_version.txt /home/gradle/sdk_version.txt
+
+COPY --chown=gradle:gradle build.gradle.kts settings.gradle.kts ./
+
+RUN SDK_VERSION=$(cat /home/gradle/sdk_version.txt) && \
+    sed -i 's|repositories {|repositories {\n\t\tmaven { url = uri("file:///home/gradle/m2") }|' build.gradle.kts && \
+    sed -i "s|com.github.fingerprintjs:java-sdk:[^\"]*|com.github.fingerprintjs:java-sdk:${SDK_VERSION}|g" build.gradle.kts
+
+RUN gradle build --no-daemon
+
+COPY --chown=gradle:gradle src /home/gradle/app/src
+
+RUN gradle clean build --no-daemon
+
+
+FROM eclipse-temurin:17-jre-focal AS start-webserver
+
+WORKDIR /app
+
+COPY --from=build /home/gradle/app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/projects/node-sdk/Dockerfile.branch
+++ b/projects/node-sdk/Dockerfile.branch
@@ -1,0 +1,37 @@
+ARG SDK_BRANCH=main
+
+FROM node:22 AS sdk-builder
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+ARG SDK_BRANCH
+
+WORKDIR /sdk
+RUN git clone --branch ${SDK_BRANCH} --depth 1 https://github.com/fingerprintjs/node-sdk.git .
+RUN npm install -g pnpm
+RUN pnpm install && pnpm run build && pnpm pack
+
+
+FROM node:22
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+COPY . /app
+WORKDIR /app
+
+RUN npm install -g pnpm
+
+COPY package.json tsconfig.json ./
+COPY ./src ./src
+
+COPY --from=sdk-builder /sdk/*.tgz /tmp/
+
+RUN pnpm install && \
+    SDK_TGZ=$(ls /tmp/*.tgz) && \
+    pnpm add ${SDK_TGZ}
+
+EXPOSE 3002
+
+CMD ["pnpm", "start"]

--- a/projects/php-sdk/Dockerfile.branch
+++ b/projects/php-sdk/Dockerfile.branch
@@ -1,0 +1,22 @@
+ARG SDK_BRANCH=main
+
+FROM php:8.2-cli
+
+ARG SDK_BRANCH
+
+RUN apt-get update -y && apt-get install -y git
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN git clone --branch ${SDK_BRANCH} --depth 1 https://github.com/fingerprintjs/php-sdk.git /sdk
+
+COPY . /app
+WORKDIR /app
+
+RUN composer config minimum-stability dev && \
+    composer config prefer-stable true && \
+    composer config repositories.fp-server-sdk '{"type":"path","url":"/sdk","options":{"symlink":false}}' && \
+    composer require fingerprint/server-sdk:'*' --no-interaction
+
+EXPOSE 3004
+
+CMD ["php", "-S", "0.0.0.0:3004", "-t", "public"]

--- a/projects/python-sdk/Dockerfile.branch
+++ b/projects/python-sdk/Dockerfile.branch
@@ -1,0 +1,21 @@
+ARG SDK_BRANCH=main
+
+FROM python:3.9-slim
+
+ARG SDK_BRANCH
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y git
+
+COPY requirements.txt requirements.txt
+
+RUN grep -v "^fingerprint[-_]server[-_]sdk" requirements.txt > /tmp/requirements_no_sdk.txt && \
+    pip install --no-cache-dir -r /tmp/requirements_no_sdk.txt && \
+    pip install --no-cache-dir git+https://github.com/fingerprintjs/python-sdk@${SDK_BRANCH}
+
+COPY . .
+
+EXPOSE 3003
+
+CMD ["python", "main.py"]


### PR DESCRIPTION
- Add `Dockerfile.branch` files to support building against a branch from the each SDK's GitHub repo.
- Add `docker-compose.branch.yml` config to override the Dockerfile to use when building each SDK image.
- Add new Makefile targets to start containers, building the SDK from a branch specified with an environment variable.
- Update README.md with info about testing against an unreleased SDK branch.
- Fix warning in `docker-compose.yml` about `version` being deprecated.