### PR TITLE
INTER-1921: Add `package-name` parameter to e2e workflow

### DIFF
--- a/.github/workflows/server-sdk-e2e-tests.yml
+++ b/.github/workflows/server-sdk-e2e-tests.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: 'latest'
+      package-name:
+        description: 'Custom package name for the SDK (defaults to new SDK package name if not provided)'
+        required: false
+        type: string
+        default: ''
       run-node-sdk-tests:
         description: 'Should we run Node SDK tests?'
         required: false
@@ -109,12 +114,12 @@ jobs:
       - name: Wait for Node SDK availability on registry
         if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
         working-directory: ./projects/node-sdk
-        run: ../../scripts/wait-for-sdk-availability.sh node ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+        run: ../../scripts/wait-for-sdk-availability.sh node ${{ github.event.client_payload.sdk-version || inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Set up Node SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/node-sdk
-        run: ../../scripts/setup-sdk.sh node ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }}
+        run: ../../scripts/setup-sdk.sh node ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Install Playwright browsers
         working-directory: ./projects/conductor
@@ -270,12 +275,12 @@ jobs:
       - name: Wait for Java SDK availability on registry
         if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
         working-directory: ./projects/java-sdk
-        run: ../../scripts/wait-for-sdk-availability.sh java ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+        run: ../../scripts/wait-for-sdk-availability.sh java ${{ github.event.client_payload.sdk-version || inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Set up Java SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/java-sdk
-        run: ../../scripts/setup-sdk.sh java ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }}
+        run: ../../scripts/setup-sdk.sh java ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Build with Gradle
         working-directory: ./projects/java-sdk
@@ -425,12 +430,12 @@ jobs:
       - name: Wait for .NET SDK availability on registry
         if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
         working-directory: ./projects/dotnet-sdk
-        run: ../../scripts/wait-for-sdk-availability.sh dotnet ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+        run: ../../scripts/wait-for-sdk-availability.sh dotnet ${{ github.event.client_payload.sdk-version || inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Set up .NET SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/dotnet-sdk
-        run: ../../scripts/setup-sdk.sh dotnet ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }}
+        run: ../../scripts/setup-sdk.sh dotnet ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Build the project
         run: dotnet publish ./projects/dotnet-sdk --configuration Release --output ./projects/dotnet-sdk/out
@@ -587,12 +592,12 @@ jobs:
       - name: Wait for Go SDK availability on registry
         if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
         working-directory: ./projects/go-sdk
-        run: ../../scripts/wait-for-sdk-availability.sh go ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+        run: ../../scripts/wait-for-sdk-availability.sh go ${{ github.event.client_payload.sdk-version || inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Set up Go SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/go-sdk
-        run: ../../scripts/setup-sdk.sh go ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }}
+        run: ../../scripts/setup-sdk.sh go ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Install dependencies
         working-directory: ./projects/go-sdk
@@ -749,12 +754,12 @@ jobs:
       - name: Wait for Python SDK availability on registry
         if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
         working-directory: ./projects/python-sdk
-        run: ../../scripts/wait-for-sdk-availability.sh python ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+        run: ../../scripts/wait-for-sdk-availability.sh python ${{ github.event.client_payload.sdk-version || inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Set up Python SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/python-sdk
-        run: ../../scripts/setup-sdk.sh python ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }}
+        run: ../../scripts/setup-sdk.sh python ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Run Python application
         working-directory: ./projects/python-sdk
@@ -910,12 +915,12 @@ jobs:
       - name: Wait for PHP SDK availability on registry
         if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.sdk-version != '' && inputs.sdk-version != 'latest') }}
         working-directory: ./projects/php-sdk
-        run: ../../scripts/wait-for-sdk-availability.sh php ${{ github.event.client_payload.sdk-version || inputs.sdk-version }}
+        run: ../../scripts/wait-for-sdk-availability.sh php ${{ github.event.client_payload.sdk-version || inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Set up PHP SDK version
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
         working-directory: ./projects/php-sdk
-        run: ../../scripts/setup-sdk.sh php ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }}
+        run: ../../scripts/setup-sdk.sh php ${{ github.event_name }} ${{ github.event.client_payload.sdk-version || github.event.inputs.sdk-version }} "${{ github.event.client_payload.package-name || inputs.package-name }}"
 
       - name: Run PHP built-in server
         working-directory: ./projects/php-sdk

--- a/scripts/setup-sdk.sh
+++ b/scripts/setup-sdk.sh
@@ -4,6 +4,7 @@ set -e
 LANGUAGE=$1        # node, java, dotnet, go, python, php
 EVENT_NAME=$2      # workflow_dispatch, push, pull_request, schedule
 SDK_VERSION=$3     # SDK version or "latest"
+PACKAGE_NAME=$4    # Optional: custom package name (empty = use default)
 
 GITHUB_REPO="fingerprintjs"
 
@@ -39,7 +40,7 @@ fi
 if [[ "$LANGUAGE" == "node" ]]; then
     # Node.js: If SDK_VERSION has only version without full tag, add the correct package name
     if [[ "$SDK_VERSION" != @* ]]; then
-        SDK_VERSION="@fingerprint/node-sdk@$SDK_VERSION"
+        SDK_VERSION="${PACKAGE_NAME:-@fingerprint/node-sdk}@$SDK_VERSION"
     fi
 fi
 
@@ -50,8 +51,10 @@ fi
 
 replace_java_dep() {
   local file="build.gradle.kts"
-  local pattern="com.github.fingerprintjs:java-sdk:[^\"' ]*"
-  local replacement="com.github.fingerprintjs:java-sdk:$SDK_VERSION"
+  local group_artifact="${PACKAGE_NAME:-com.github.fingerprintjs:java-sdk}"
+  local escaped_ga=$(echo "$group_artifact" | sed 's/\./\\./g')
+  local pattern="${escaped_ga}:[^\"' ]*"
+  local replacement="${group_artifact}:$SDK_VERSION"
 
   if command -v gsed >/dev/null 2>&1; then
     # GNU sed (often installed as gsed on macOS via Homebrew)
@@ -81,17 +84,17 @@ case $LANGUAGE in
         ./gradlew dependencies --refresh-dependencies
         ;;
     "dotnet")
-        dotnet add package Fingerprint.ServerSdk --version $SDK_VERSION
+        dotnet add package "${PACKAGE_NAME:-Fingerprint.ServerSdk}" --version $SDK_VERSION
         ;;
     "go")
         MAJOR_VERSION=$(echo $SDK_VERSION | cut -d'.' -f1)
-        go get github.com/fingerprintjs/go-sdk/$MAJOR_VERSION@$SDK_VERSION
+        go get "${PACKAGE_NAME:-github.com/fingerprintjs/go-sdk}"/$MAJOR_VERSION@$SDK_VERSION
         ;;
     "python")
-        pip install "fingerprint-server-sdk==$SDK_VERSION"
+        pip install "${PACKAGE_NAME:-fingerprint-server-sdk}==$SDK_VERSION"
         ;;
     "php")
-        composer require fingerprint/server-sdk:$SDK_VERSION --update-with-dependencies
+        composer require "${PACKAGE_NAME:-fingerprint/server-sdk}":$SDK_VERSION --update-with-dependencies
         ;;
     *)
         echo "Unknown language: $LANGUAGE"

--- a/scripts/wait-for-sdk-availability.sh
+++ b/scripts/wait-for-sdk-availability.sh
@@ -3,6 +3,7 @@ set -e
 
 LANGUAGE=$1
 SDK_VERSION=$2
+PACKAGE_NAME=$3    # Optional: custom package name (empty = use default)
 
 MAX_ATTEMPTS=30
 INITIAL_DELAY=10
@@ -10,7 +11,7 @@ MAX_DELAY=60
 CURL_OPTS=(-sf -o /dev/null)
 
 if [[ -z "$LANGUAGE" || -z "$SDK_VERSION" ]]; then
-    echo "Usage: wait-for-sdk-availability.sh <language> <version>"
+    echo "Usage: wait-for-sdk-availability.sh <language> <version> [package-name]"
     echo "Languages: node, java, dotnet, go, python, php"
     exit 1
 fi
@@ -22,28 +23,39 @@ with_v="v$strip_v"
 case $LANGUAGE in
     "node")
         VERSION="$strip_v"
-        CHECK_URL="https://registry.npmjs.org/@fingerprint%2Fnode-sdk/$VERSION"
+        NODE_PACKAGE="${PACKAGE_NAME:-@fingerprint/node-sdk}"
+        ENCODED_PACKAGE="${NODE_PACKAGE/\//%2F}"
+        CHECK_URL="https://registry.npmjs.org/${ENCODED_PACKAGE}/$VERSION"
         ;;
     "java")
         VERSION="$with_v"
-        CHECK_URL="https://jitpack.io/com/github/fingerprintjs/java-sdk/$VERSION/java-sdk-$VERSION.pom"
+        JAVA_PACKAGE="${PACKAGE_NAME:-com.github.fingerprintjs:java-sdk}"
+        JAVA_GROUP=$(echo "$JAVA_PACKAGE" | cut -d: -f1)
+        JAVA_ARTIFACT=$(echo "$JAVA_PACKAGE" | cut -d: -f2)
+        JAVA_GROUP_PATH=$(echo "$JAVA_GROUP" | tr '.' '/')
+        CHECK_URL="https://jitpack.io/${JAVA_GROUP_PATH}/${JAVA_ARTIFACT}/${VERSION}/${JAVA_ARTIFACT}-${VERSION}.pom"
         ;;
     "dotnet")
         VERSION=$(echo "$strip_v" | tr '[:upper:]' '[:lower:]')
-        CHECK_URL="https://api.nuget.org/v3-flatcontainer/fingerprint.serversdk/$VERSION/fingerprint.serversdk.nuspec"
+        DOTNET_PACKAGE="${PACKAGE_NAME:-Fingerprint.ServerSdk}"
+        DOTNET_LOWER=$(echo "$DOTNET_PACKAGE" | tr '[:upper:]' '[:lower:]')
+        CHECK_URL="https://api.nuget.org/v3-flatcontainer/${DOTNET_LOWER}/${VERSION}/${DOTNET_LOWER}.nuspec"
         ;;
     "go")
         VERSION="$with_v"
         MAJOR_VERSION=$(echo "$VERSION" | cut -d'.' -f1)
-        CHECK_URL="https://proxy.golang.org/github.com/fingerprintjs/go-sdk/$MAJOR_VERSION/@v/$VERSION.info"
+        GO_MODULE="${PACKAGE_NAME:-github.com/fingerprintjs/go-sdk}"
+        CHECK_URL="https://proxy.golang.org/${GO_MODULE}/${MAJOR_VERSION}/@v/${VERSION}.info"
         ;;
     "python")
         VERSION="$strip_v"
-        CHECK_URL="https://pypi.org/pypi/fingerprint-server-sdk/$VERSION/json"
+        PY_PACKAGE="${PACKAGE_NAME:-fingerprint-server-sdk}"
+        CHECK_URL="https://pypi.org/pypi/${PY_PACKAGE}/${VERSION}/json"
         ;;
     "php")
         VERSION="$strip_v"
-        CHECK_URL="https://repo.packagist.org/p2/fingerprint/server-sdk.json"
+        PHP_PACKAGE="${PACKAGE_NAME:-fingerprint/server-sdk}"
+        CHECK_URL="https://repo.packagist.org/p2/${PHP_PACKAGE}.json"
         ;;
     *)
         echo "Unknown language: $LANGUAGE"
@@ -55,7 +67,7 @@ check_version_available() {
     # PHP requires parsing the JSON response to find the specific version
     if [[ "$LANGUAGE" == "php" ]]; then
         curl -sf "$CHECK_URL" | \
-            jq -e ".packages[\"fingerprint/server-sdk\"][] | select(.version == \"$VERSION\")" > /dev/null
+            jq -e ".packages[\"${PHP_PACKAGE}\"][] | select(.version == \"$VERSION\")" > /dev/null
     else
         curl "${CURL_OPTS[@]}" "$CHECK_URL"
     fi


### PR DESCRIPTION
## Summary

- Add optional `package-name` input
- Update `setup-sdk.sh` and `wait-for-sdk-availability.sh` to use the custom package name when provided, falling back to the current defaults
- Backward compatible. No changes needed for new SDKs

## Context

Old SDK versions use different package names on their registries:

| SDK | Old Package | New Package (default, currently we use) |
|-----|-------------|----------------------|
| Node | `@fingerprintjs/fingerprintjs-pro-server-api` | `@fingerprint/node-sdk` |
| Java | `com.github.fingerprintjs:fingerprint-pro-server-api-java-sdk` | `com.github.fingerprintjs:java-sdk` |
| .NET | `FingerprintPro.ServerSdk` | `Fingerprint.ServerSdk` |
| Go | `github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk` | `github.com/fingerprintjs/go-sdk` |
| Python | `fingerprint_pro_server_api_sdk` | `fingerprint-server-sdk` |
| PHP | `fingerprint/fingerprint-pro-server-api-sdk` | `fingerprint/server-sdk` |

SDK repos can now pass `package-name` in the `repository_dispatch` payload to test old versions.