### PR TITLE
test: update thatResponsesMatch for change in pagination key behavior

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
   projects/node-sdk:
     dependencies:
       '@fingerprint/node-sdk':
-        specifier: 7.3.0-test.0
-        version: 7.3.0-test.0
+        specifier: 7.3.0
+        version: 7.3.0
       '@fingerprintjs/fingerprintjs-pro-server-api':
         specifier: 6.11.0
         version: 6.11.0
@@ -102,6 +102,10 @@ packages:
 
   '@fingerprint/agent@4.0.1':
     resolution: {integrity: sha512-8+XUD3vP60Q5wpunaf932kp1lW2xWyXgI7f50EDAjoVNaNB7Y4T9qKam19y3WkgbipXnLdmekvNGtxEeyF+r9A==}
+
+  '@fingerprint/node-sdk@7.3.0':
+    resolution: {integrity: sha512-y0gv2ZF4PJDz2u98p4AZR3smM4DP21DfSo9tQoJQc7g5Y0nYVc1CJouoS5eqIUyrVSk8JZET0DZZvHomoNjodg==}
+    engines: {node: '>=18.17.0'}
 
   '@fingerprint/node-sdk@7.3.0-test.0':
     resolution: {integrity: sha512-42U8P9R5wkRrx9d53+6MXfOSzvuX36cLmTkxCnx8hpqtMBeC14aJgefXY7YT+z2bbFIc6CsflaQZpwEeXz0NTA==}
@@ -283,6 +287,7 @@ packages:
 
   '@ungap/structured-clone@1.2.1':
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1117,6 +1122,8 @@ snapshots:
   '@eslint/js@8.56.0': {}
 
   '@fingerprint/agent@4.0.1': {}
+
+  '@fingerprint/node-sdk@7.3.0': {}
 
   '@fingerprint/node-sdk@7.3.0-test.0': {}
 

--- a/projects/conductor/utils/assertions.ts
+++ b/projects/conductor/utils/assertions.ts
@@ -30,6 +30,14 @@ export class Assertions {
     const realResponse: JsonResponse<any> = await this.fingerprintApi[method].call(this.fingerprintApi, ...params)
     const sdkResponse: JsonResponse<any> = await this.sdksApi[method].call(this.sdksApi, ...params)
 
+    if (method === 'searchEvents') {
+      // The pagination  will be different in each response so just validate that
+      // the truthiness of the pagination keys match
+      expect(!!sdkResponse.data?.paginationKey).toEqual(!!realResponse.data?.paginationKey)
+      delete sdkResponse.data?.paginationKey
+      delete realResponse.data?.paginationKey
+    }
+
     expect(sdkResponse.data).toMatchObject(realResponse.data)
     return sdkResponse.data
   }

--- a/projects/conductor/utils/assertions.ts
+++ b/projects/conductor/utils/assertions.ts
@@ -36,9 +36,7 @@ export class Assertions {
     if (method === 'searchEvents') {
       // The pagination  will be different in each response so just validate that
       // both responses either include it or omit it
-      const sdkHasPaginationKey = Object.prototype.hasOwnProperty.call(sdkData, 'paginationKey')
-      const realHasPaginationKey = Object.prototype.hasOwnProperty.call(realData, 'paginationKey')
-      expect(sdkHasPaginationKey).toEqual(realHasPaginationKey)
+      expect(!!sdkData.paginationKey).toEqual(!!realData.paginationKey)
 
       delete realData.paginationKey
       delete sdkData.paginationKey

--- a/projects/conductor/utils/assertions.ts
+++ b/projects/conductor/utils/assertions.ts
@@ -1,4 +1,4 @@
-import { ExtractFingerprintApiReturnType, FingerprintApi, GetEventsParams } from './api';
+import { ExtractFingerprintApiReturnType, FingerprintApi, GetEventsParams } from './api'
 import { expect } from '@playwright/test'
 import { JsonResponse } from './http'
 import { EventsGetResponse } from '@fingerprintjs/fingerprintjs-pro-server-api'
@@ -30,15 +30,21 @@ export class Assertions {
     const realResponse: JsonResponse<any> = await this.fingerprintApi[method].call(this.fingerprintApi, ...params)
     const sdkResponse: JsonResponse<any> = await this.sdksApi[method].call(this.sdksApi, ...params)
 
+    const realData = { ...realResponse.data }
+    const sdkData = { ...sdkResponse.data }
+
     if (method === 'searchEvents') {
       // The pagination  will be different in each response so just validate that
-      // the truthiness of the pagination keys match
-      expect(!!sdkResponse.data?.paginationKey).toEqual(!!realResponse.data?.paginationKey)
-      delete sdkResponse.data?.paginationKey
-      delete realResponse.data?.paginationKey
+      // both responses either include it or omit it
+      const sdkHasPaginationKey = Object.prototype.hasOwnProperty.call(sdkData, 'paginationKey')
+      const realHasPaginationKey = Object.prototype.hasOwnProperty.call(realData, 'paginationKey')
+      expect(sdkHasPaginationKey).toEqual(realHasPaginationKey)
+
+      delete realData.paginationKey
+      delete sdkData.paginationKey
     }
 
-    expect(sdkResponse.data).toMatchObject(realResponse.data)
+    expect(sdkData).toMatchObject(realData)
     return sdkResponse.data
   }
 

--- a/projects/conductor/utils/v4/assertions.ts
+++ b/projects/conductor/utils/v4/assertions.ts
@@ -30,15 +30,21 @@ export class AssertionsV4 {
     const realResponse: JsonResponse<any> = await this.fingerprintApi[method].call(this.fingerprintApi, ...params)
     const sdkResponse: JsonResponse<any> = await this.sdksApi[method].call(this.sdksApi, ...params)
 
+    const realData = { ...realResponse.data }
+    const sdkData = { ...sdkResponse.data }
+
     if (method === 'searchEvents') {
       // The pagination  will be different in each response so just validate that
-      // the truthiness of the pagination keys match
-      expect(!!sdkResponse.data?.pagination_key).toEqual(!!realResponse.data?.pagination_key)
-      delete sdkResponse.data?.pagination_key
-      delete realResponse.data?.pagination_key
+      // both responses either include it or omit it
+      const sdkHasPaginationKey = Object.prototype.hasOwnProperty.call(sdkData, 'pagination_key')
+      const realHasPaginationKey = Object.prototype.hasOwnProperty.call(realData, 'pagination_key')
+      expect(sdkHasPaginationKey).toEqual(realHasPaginationKey)
+
+      delete realData.pagination_key
+      delete sdkData.pagination_key
     }
 
-    expect(sdkResponse.data).toMatchObject(realResponse.data)
+    expect(sdkData).toMatchObject(realData)
     return sdkResponse.data
   }
 

--- a/projects/conductor/utils/v4/assertions.ts
+++ b/projects/conductor/utils/v4/assertions.ts
@@ -36,9 +36,7 @@ export class AssertionsV4 {
     if (method === 'searchEvents') {
       // The pagination  will be different in each response so just validate that
       // both responses either include it or omit it
-      const sdkHasPaginationKey = Object.prototype.hasOwnProperty.call(sdkData, 'pagination_key')
-      const realHasPaginationKey = Object.prototype.hasOwnProperty.call(realData, 'pagination_key')
-      expect(sdkHasPaginationKey).toEqual(realHasPaginationKey)
+      expect(!!sdkData.pagination_key).toEqual(realData.pagination_key)
 
       delete realData.pagination_key
       delete sdkData.pagination_key

--- a/projects/conductor/utils/v4/assertions.ts
+++ b/projects/conductor/utils/v4/assertions.ts
@@ -30,6 +30,14 @@ export class AssertionsV4 {
     const realResponse: JsonResponse<any> = await this.fingerprintApi[method].call(this.fingerprintApi, ...params)
     const sdkResponse: JsonResponse<any> = await this.sdksApi[method].call(this.sdksApi, ...params)
 
+    if (method === 'searchEvents') {
+      // The pagination  will be different in each response so just validate that
+      // the truthiness of the pagination keys match
+      expect(!!sdkResponse.data?.pagination_key).toEqual(!!realResponse.data?.pagination_key)
+      delete sdkResponse.data?.pagination_key
+      delete realResponse.data?.pagination_key
+    }
+
     expect(sdkResponse.data).toMatchObject(realResponse.data)
     return sdkResponse.data
   }

--- a/projects/dotnet-sdk/dotnet-sdk.csproj
+++ b/projects/dotnet-sdk/dotnet-sdk.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fingerprint.ServerSdk" Version="8.3.0-test.1" />
+    <PackageReference Include="Fingerprint.ServerSdk" Version="8.3.0" />
     <PackageReference Include="FingerprintPro.ServerSdk" Version="7.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/projects/go-sdk/go.mod
+++ b/projects/go-sdk/go.mod
@@ -4,4 +4,4 @@ go 1.23.0
 
 require github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7 v7.10.0
 
-require github.com/fingerprintjs/go-sdk/v8 v8.3.0-test.0
+require github.com/fingerprintjs/go-sdk/v8 v8.3.0

--- a/projects/go-sdk/go.sum
+++ b/projects/go-sdk/go.sum
@@ -4,3 +4,5 @@ github.com/fingerprintjs/go-sdk/v8 v8.1.0 h1:4rjCO6RtMZ7YIX7zIGgp/cAfltzwGNY50Lr
 github.com/fingerprintjs/go-sdk/v8 v8.1.0/go.mod h1:keVuTTvDofQYjzm6t+YXPZ9twIIk4UzpXOoXhJhjySc=
 github.com/fingerprintjs/go-sdk/v8 v8.3.0-test.0 h1:pd34sASE42cNIWllegK8zb2fc8DLBYfCJxn6kvrfCYI=
 github.com/fingerprintjs/go-sdk/v8 v8.3.0-test.0/go.mod h1:keVuTTvDofQYjzm6t+YXPZ9twIIk4UzpXOoXhJhjySc=
+github.com/fingerprintjs/go-sdk/v8 v8.3.0 h1:tcyMebCpG3zEhT9bHqorbFh/5p5yZrVwxhZGnbd/usc=
+github.com/fingerprintjs/go-sdk/v8 v8.3.0/go.mod h1:keVuTTvDofQYjzm6t+YXPZ9twIIk4UzpXOoXhJhjySc=

--- a/projects/java-sdk/build.gradle.kts
+++ b/projects/java-sdk/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	implementation("com.github.fingerprintjs:fingerprint-pro-server-api-java-sdk:v7.12.0")
-	implementation("com.github.fingerprintjs:java-sdk:v8.3.0-rc.1")
+	implementation("com.github.fingerprintjs:java-sdk:v8.3.0")
 }
 
 tasks.withType<Test> {

--- a/projects/node-sdk/package.json
+++ b/projects/node-sdk/package.json
@@ -6,7 +6,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@fingerprint/node-sdk": "7.3.0-test.0",
+    "@fingerprint/node-sdk": "7.3.0",
     "@fingerprintjs/fingerprintjs-pro-server-api": "6.11.0",
     "express": "^5.0.1",
     "ts-node": "^10.9.2",

--- a/projects/php-sdk/composer.json
+++ b/projects/php-sdk/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "fingerprint/fingerprint-pro-server-api-sdk": "6.11.0",
-        "fingerprint/server-sdk": "7.2.0-beta.2",
+        "fingerprint/server-sdk": "7.2.0",
         "slim/slim": "^4.15.1"
     },
     "autoload": {

--- a/projects/php-sdk/composer.lock
+++ b/projects/php-sdk/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15725ec59a7242e4834bbe7bee31dcd3",
+    "content-hash": "04c8f74597db47955a99d6b30dd8d744",
     "packages": [
         {
             "name": "fingerprint/fingerprint-pro-server-api-sdk",
@@ -78,16 +78,16 @@
         },
         {
             "name": "fingerprint/server-sdk",
-            "version": "7.2.0-beta.2",
+            "version": "7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fingerprintjs/php-sdk.git",
-                "reference": "58c3f1b9bb6224f215aa12cbb9b0643bcfacfaac"
+                "reference": "36e2bce71b6519b33be8b2c9527aa2ecf69dfdfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fingerprintjs/php-sdk/zipball/58c3f1b9bb6224f215aa12cbb9b0643bcfacfaac",
-                "reference": "58c3f1b9bb6224f215aa12cbb9b0643bcfacfaac",
+                "url": "https://api.github.com/repos/fingerprintjs/php-sdk/zipball/36e2bce71b6519b33be8b2c9527aa2ecf69dfdfb",
+                "reference": "36e2bce71b6519b33be8b2c9527aa2ecf69dfdfb",
                 "shasum": ""
             },
             "require": {
@@ -147,31 +147,32 @@
             ],
             "support": {
                 "issues": "https://github.com/fingerprintjs/php-sdk/issues",
-                "source": "https://github.com/fingerprintjs/php-sdk/tree/v7.2.0-beta.2"
+                "source": "https://github.com/fingerprintjs/php-sdk/tree/v7.2.0"
             },
-            "time": "2026-05-21T09:55:52+00:00"
+            "time": "2026-05-26T17:41:37+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.2",
+            "version": "7.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "aed36fd5fb4844f284252a999d9abf35d3a9a1ae"
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aed36fd5fb4844f284252a999d9abf35d3a9a1ae",
-                "reference": "aed36fd5fb4844f284252a999d9abf35d3a9a1ae",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -180,7 +181,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.3.2",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -260,7 +261,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
             },
             "funding": [
                 {
@@ -276,24 +277,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T11:58:52+00:00"
+            "time": "2026-06-07T22:54:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.1",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "d2d8dfae4757f384d630fdffc2d8d6618d8f4c5e"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/d2d8dfae4757f384d630fdffc2d8d6618d8f4c5e",
-                "reference": "d2d8dfae4757f384d630fdffc2d8d6618d8f4c5e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -343,7 +345,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -359,27 +361,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-19T18:30:48+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.10.1",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
-                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -460,7 +464,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -476,7 +480,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T09:27:36+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -1139,9 +1143,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "fingerprint/server-sdk": 10
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/projects/python-sdk/requirements.txt
+++ b/projects/python-sdk/requirements.txt
@@ -1,4 +1,4 @@
 fingerprint_pro_server_api_sdk==8.13.0
-fingerprint-server-sdk==9.3.0-rc.0
+fingerprint-server-sdk==9.3.0
 flask>=3.1
 pydantic>=2


### PR DESCRIPTION
## Overview
Update test assertions to address these failures:
```
    [chromium v3] › tests/v3/004-searchEvents.test.ts:247:3 › SearchEvents suite › with paginationKey 
    [chromium v3] › tests/v3/004-searchEvents.test.ts:269:3 › SearchEvents suite › with paginationKey reversed 
```

NOTE: there are a number of other unrelated failures in the tests. Work is ongoing to address those.

## Itemized Changes
- Update the `thatResponsesMatch` assertion to validate that the pagination key is present in or absent in both responses. The server API was recently updated to use a unique pagination key for each server API response. The server API contract did not require the pagination key to remain the same given the same inputs so the test assertions need to be relaxed to account for this behavior.
- Update SDK projects to use the latest versions. This is a cleanup item that results in using the latest SDK version when running the test projects locally.