### PR TITLE
chore: fix v3 visitors test failures

### DIFF
--- a/projects/conductor/tests/v3/002-getVisitor.test.ts
+++ b/projects/conductor/tests/v3/002-getVisitor.test.ts
@@ -2,6 +2,7 @@ import { testData } from '../../utils/testData'
 import { test } from '../../utils/playwright'
 import { expect } from '@playwright/test'
 import { getRandomDevice } from '../../htmlScripts/runIdentification'
+import { withRetry } from '../../utils/retry'
 
 test.describe('GetVisitor Suite', () => {
   test('with valid apiKey', async ({ assert, identify }) => {
@@ -95,25 +96,33 @@ test.describe('GetVisitor Suite', () => {
         auth: testData.credentials.maxFeaturesUS,
         device: getRandomDevice(),
       },
-      10
+      2
     )
 
     const params = {
       apiKey: testData.credentials.maxFeaturesUS.privateKey,
       visitorId: visitors[0].visitorId,
-      limit: 5,
+      limit: 1,
       region: testData.credentials.maxFeaturesUS.region,
     }
 
-    const { data } = await sdkApi.getVisitor(params)
-    expect(data.visits).toHaveLength(5)
+    const data = await withRetry(
+      async () => {
+        const { data } = await sdkApi.getVisitor(params)
+        expect(data.visits).toHaveLength(1)
+        return data
+      },
+      {
+        waitMs: 5000,
+      }
+    )
 
     const { data: nextData } = await sdkApi.getVisitor({
       ...params,
       paginationKey: data.paginationKey,
     })
 
-    expect(nextData.visits).toHaveLength(5)
+    expect(nextData.visits).toHaveLength(1)
     expect(nextData.visits).not.toEqual(data.visits)
   })
 
@@ -124,20 +133,29 @@ test.describe('GetVisitor Suite', () => {
       linkedId,
     })
 
-    const { data } = await sdkApi.getVisitor({
-      apiKey: testData.credentials.maxFeaturesUS.privateKey,
-      linkedId,
-      visitorId,
-      requestId,
-    })
+    await withRetry(
+      async () => {
+        const { data } = await sdkApi.getVisitor({
+          apiKey: testData.credentials.maxFeaturesUS.privateKey,
+          linkedId,
+          visitorId,
+          requestId,
+        })
 
-    expect(data.visits).toHaveLength(1)
+        expect(data.visits).toHaveLength(1)
+      },
+      {
+        waitMs: 5000,
+      }
+    )
 
+    // The requestId filter takes precedence over the other filter parameters
+    // now and will return the associated event with the request ID, ignoring
+    // the other filter parameters.
     const { data: emptyData } = await sdkApi.getVisitor({
       apiKey: testData.credentials.maxFeaturesUS.privateKey,
       linkedId: 'different',
       visitorId,
-      requestId,
     })
 
     expect(emptyData.visits).toHaveLength(0)

--- a/projects/conductor/tests/v3/100-deleteVisitorData.test.ts
+++ b/projects/conductor/tests/v3/100-deleteVisitorData.test.ts
@@ -26,11 +26,7 @@ test.describe('DeleteVisitorData Suite', () => {
 
     await assert.thatResponseMatch({
       strict: false,
-      expectedResponse: {
-        visitorId,
-        visits: [],
-      },
-      expectedStatusCode: 200,
+      expectedStatusCode: 404,
       callback: (api) =>
         api.getVisitor({
           visitorId,

--- a/projects/conductor/tests/v3/100-deleteVisitorData.test.ts
+++ b/projects/conductor/tests/v3/100-deleteVisitorData.test.ts
@@ -25,7 +25,6 @@ test.describe('DeleteVisitorData Suite', () => {
     await waitBeforeFetch()
 
     await assert.thatResponseMatch({
-      strict: false,
       expectedStatusCode: 404,
       callback: (api) =>
         api.getVisitor({

--- a/projects/conductor/utils/v4/assertions.ts
+++ b/projects/conductor/utils/v4/assertions.ts
@@ -36,7 +36,7 @@ export class AssertionsV4 {
     if (method === 'searchEvents') {
       // The pagination  will be different in each response so just validate that
       // both responses either include it or omit it
-      expect(!!sdkData.pagination_key).toEqual(realData.pagination_key)
+      expect(!!sdkData.pagination_key).toEqual(!!realData.pagination_key)
 
       delete realData.pagination_key
       delete sdkData.pagination_key


### PR DESCRIPTION
- Update the v3 `getVisitor` `with pagination` test to expect a single visit per page rather than a user-specified amount of visits per page. Recent changes to the server API have updated the `GET /visitors/{visitor_id}` endpoint to always return a single visit.
- Update the v3 `getVisitor` `with linked id` test to remove the `requestId` filter parameter from the test to look up a non-existent linked ID. If the `requestId` filter parameter is now present, the corresponding event will always be returned.
- Use `withRetry` to retry lookups for recently created identification events rather than retry the whole test case. This accounts for the eventual consistency of the lookups.


Unrelated, follow-up change from #70:
- Fix the v4 assertion added for the pagination key in the search events. This change should have been in #70 but I mistakenly removed it.

This change was originally included in this PR but it led to the tests reliably seeing rate limits so I've broken it out into #72:
- Update the v3 `RealFingerprintApi` class to fix the update event and delete visitor calls to use the correct HTTP methods.