### PR TITLE
chore: fix v3 RealFingerprintApi update event, delete visitor calls

### DIFF
--- a/projects/conductor/utils/api.ts
+++ b/projects/conductor/utils/api.ts
@@ -177,7 +177,8 @@ export class RealFingerprintApi implements FingerprintApi {
     return await jsonRequest<void>({
       request: this.request,
       url: `${testData.config.apiUrl}/events/${requestId}`,
-      data,
+      params: data,
+      method: 'put',
       headers: {
         'Auth-API-Key': apiKey,
         'content-type': 'application/json',
@@ -309,6 +310,7 @@ export class RealFingerprintApi implements FingerprintApi {
     return await jsonRequest<void>({
       request: this.request,
       url: `${testData.config.apiUrl}/visitors/${params.visitorId}`,
+      method: 'delete',
       headers: {
         'Auth-API-Key': params.apiKey,
         'content-type': 'application/json',

--- a/projects/conductor/utils/http.ts
+++ b/projects/conductor/utils/http.ts
@@ -71,7 +71,7 @@ export async function jsonRequest<T = any>({
     if (queryString) {
       finalUrl = url.includes('?') ? `${url}&${queryString}` : `${url}?${queryString}`
     }
-  } else if (['post', 'patch', 'put'].includes(method)) {
+  } else if (['post', 'patch', 'put', 'delete'].includes(method)) {
     args.data = params
   }
 

--- a/projects/conductor/utils/http.ts
+++ b/projects/conductor/utils/http.ts
@@ -5,7 +5,7 @@ export type RequestParams = Record<string, Primitive | Primitive[]>
 
 type MethodVariants =
   | { method?: 'get'; params?: RequestParams }
-  | { method: 'post' | 'patch'| 'delete'; params?: any }
+  | { method: 'post' | 'patch'| 'delete' | 'put'; params?: any }
 
 type JsonRequestOptions = {
   request: APIRequestContext
@@ -71,7 +71,7 @@ export async function jsonRequest<T = any>({
     if (queryString) {
       finalUrl = url.includes('?') ? `${url}&${queryString}` : `${url}?${queryString}`
     }
-  } else if (['post', 'patch'].includes(method)) {
+  } else if (['post', 'patch', 'put'].includes(method)) {
     args.data = params
   }
 


### PR DESCRIPTION
- Update the `RealFingerprintApi` class to fix the update event and delete visitor calls to use the correct HTTP methods.